### PR TITLE
Extract pure ariadne-related code from server.py

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+init-hook="from pylint.config import find_pylintrc; import os, sys; sys.path.append(os.path.dirname(find_pylintrc()))"

--- a/graphql_service/ariadne_app.py
+++ b/graphql_service/ariadne_app.py
@@ -1,0 +1,39 @@
+"""
+.. See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+import ariadne
+from graphql_service.resolver.gene_model import query, gene, transcript, locus
+
+def prepare_executable_schema():
+    """
+    Combine schema definitions with corresponding resolvers
+    """
+    schema = ariadne.load_schema_from_path('common/schemas')
+    return ariadne.make_executable_schema(
+        schema,
+        query,
+        gene,
+        transcript,
+        locus
+    )
+
+def prepare_context_provider(context):
+    """
+    Returns function for injecting context to graphql executors.
+    The context will contain a pre-configured DB client and other goodies.
+    """
+    def context_provider(request):
+        context['request'] = request
+        return context
+    return context_provider


### PR DESCRIPTION
## Description
### 1. Extract Ariadne-related code from server.py
**Reason:** By encapsulating the schemas and the resolvers in a separate module, we separate the purely Ariadne-related code from the configuration code related to production. This should (hopefully) make it easy to reuse Ariadne's graphql executors in tests, when instead of injecting production objects into context, we will inject mock ones.

### 2. Add `.pylintrc`
**Reason:** In fairly deeply nested files (such as `graphql_service/resolver/tests/test_resolvers`) pylint is unhappy about imports starting from the root of the project, because it does not know where the root is. This little fix in `.pylintrc` helps pylint orient itself.

Before:
<img width="533" alt="Screenshot 2020-05-06 at 22 51 13" src="https://user-images.githubusercontent.com/6834224/81232977-cbf3e000-8fed-11ea-959f-98856340e917.png">

After:
![image](https://user-images.githubusercontent.com/6834224/81233016-df06b000-8fed-11ea-82fa-edeb1e7a8ac9.png)
_(pylint is now happy about the import of graphql_service.resolver.dat_loaders and only complains about the import order of asyncio)_