### PR TITLE
Add Starlette server to enable CORS

### DIFF
--- a/graphql_service/server.py
+++ b/graphql_service/server.py
@@ -15,6 +15,9 @@
 import os
 
 from ariadne.asgi import GraphQL
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.middleware.cors import CORSMiddleware
 from common.utils import load_config
 from common.crossrefs import XrefResolver
 import common.mongo as mongo
@@ -40,4 +43,9 @@ CONTEXT_PROVIDER = prepare_context_provider({
     'XrefResolver': RESOLVER
 })
 
-APP = GraphQL(EXECUTABLE_SCHEMA, debug=True, context_value=CONTEXT_PROVIDER)
+starlette_middleware = [
+    Middleware(CORSMiddleware, allow_origins=['*'], allow_methods=['GET', 'POST'])
+]
+
+APP = Starlette(debug=True, middleware=starlette_middleware)
+APP.mount("/", GraphQL(EXECUTABLE_SCHEMA, debug=True, context_value=CONTEXT_PROVIDER))

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,6 @@ pytest
 pytest-asyncio
 python-dotenv
 snapshottest
+starlette
 requests
 uvicorn


### PR DESCRIPTION
# Description
## Problem
Currently, Thoas does not accept cross-origin requests. Which it has to do when it becomes a public-facing service. Meanwhile, the web team will also be able to query Thoas directly from the browser rather than proxy requests to it through a proxy server.

## CORS and Ariadne
In order to support cross-origin requests, the server has to know how to respond to `OPTIONS` requests. Ariadne developers decided not to add this functionality to Ariadne itself, but to rely on other servers to do this (discussed in this issue: `https://github.com/mirumee/ariadne/issues/104#issuecomment-531218205`).

For ASGI servers (as is currently used in Thoas), the Ariadne team suggests using a server called Starlette (🙄). See issue `https://github.com/mirumee/ariadne-website/issues/5`.

## References to docs
- Ariadne integration with Starlette: https://ariadnegraphql.org/docs/starlette-integration
- Running Starlette with CORS middleware: https://www.starlette.io/middleware

## Changes in this PR
This PR adds Starlette to Thoas, using the CORS middleware with Starlette.

Tested locally to make sure that the server runs correctly and is capable of serving cross-origin requests.