### PR TITLE
Add absent transcript cross-ref resolver

### DIFF
--- a/graphql_service/resolver/gene_model.py
+++ b/graphql_service/resolver/gene_model.py
@@ -44,24 +44,15 @@ def resolve_gene(_, info, bySymbol=None, byId=None):
     return result
 
 @GENE_TYPE.field('cross_references')
-def insert_urls(gene, info):
+@TRANSCRIPT_TYPE.field('cross_references')
+def insert_crossref_urls(feature, info):
     '''
-    A gene with cross references in the data model is given as argument.
-    Using the crossrefs package we can infer URLs to those resources
+    A gene/transcript with cross references in the data model is given as
+    argument. Using the crossrefs package we can infer URLs to those resources
     and inject them into the response
     '''
     resolver = info.context['XrefResolver']
-    xrefs = gene['cross_references']
-    return list(map(resolver.annotate_crossref, xrefs))
-
-@TRANSCRIPT_TYPE.field('cross_references')
-def insert_urls(transcript, info):
-    '''
-    As per the cross_references resolver for gene, we infer URLs
-    for xrefs on the provided transcript
-    '''
-    resolver = info.context['XrefResolver']
-    xrefs = transcript['cross_references']
+    xrefs = feature['cross_references']
     return list(map(resolver.annotate_crossref, xrefs))
 
 @QUERY_TYPE.field('transcript')

--- a/graphql_service/resolver/tests/test_resolvers.py
+++ b/graphql_service/resolver/tests/test_resolvers.py
@@ -229,7 +229,7 @@ def test_url_generation(basic_data):
         }
     }
 
-    result = model.insert_urls(
+    result = model.insert_crossref_urls(
         {
             'cross_references': [
                 xref


### PR DESCRIPTION
This module could do with refactoring. The TRANSCRIPT_TYPE resolver cross-references was overlooked.