### PR TITLE
Add genome id and stable id or symbol to gene not found error

### DIFF
--- a/graphql_service/resolver/gene_model.py
+++ b/graphql_service/resolver/gene_model.py
@@ -145,9 +145,17 @@ class GeneNotFoundError(GraphQLError):
     def __init__(self, bySymbol=None, byId=None):
         message = None
         if bySymbol:
+            symbol = bySymbol['symbol']
+            genome_id = bySymbol['genome_id']
             message = 'Failed to find gene with symbol '\
-                     f"'{bySymbol['symbol']}' for genome '{bySymbol['genome_id']}'"
+                     f"'{symbol}' for genome '{genome_id}'"
+            self.extensions['symbol'] = symbol
+            self.extensions['genome_id'] = genome_id
         if byId:
+            stable_id = byId['stable_id']
+            genome_id = byId['genome_id']
             message = 'Failed to find gene with stable id '\
-                f"'{byId['stable_id']}' for genome '{byId['genome_id']}'"
+                f"'{stable_id}' for genome '{genome_id}'"
+            self.extensions['stable_id'] = stable_id
+            self.extensions['genome_id'] = genome_id
         super().__init__(message, extensions=self.extensions)

--- a/graphql_service/resolver/tests/test_resolvers.py
+++ b/graphql_service/resolver/tests/test_resolvers.py
@@ -121,6 +121,9 @@ def test_resolve_gene(basic_data):
         )
     assert not result
     assert graphql_error.value.extensions['code'] == 'GENE_NOT_FOUND'
+    assert graphql_error.value.extensions['symbol'] == 'very not here'
+    assert graphql_error.value.extensions['genome_id'] == 1
+
     graphql_error = None
 
     result = model.resolve_gene(
@@ -140,6 +143,8 @@ def test_resolve_gene(basic_data):
         )
     assert not result
     assert graphql_error.value.extensions['code'] == 'GENE_NOT_FOUND'
+    assert graphql_error.value.extensions['stable_id'] == 'BROKEN BROKEN BROKEN'
+    assert graphql_error.value.extensions['genome_id'] == 1
     graphql_error = None
 
     # Check unversioned query resolves as well


### PR DESCRIPTION
Addressing @kamaldodiya's suggestion from [here](https://github.com/Ensembl/ensembl-thoas/pull/16#issuecomment-662434687) — adding genome id and symbol/stable_id to the error to make it more useful.