### PR TITLE
Deploy to Live WP-HL/HX Web k8s Cluster

### DIFF
--- a/web/web-gitlab-ci.yml
+++ b/web/web-gitlab-ci.yml
@@ -87,3 +87,19 @@ internal:wp-hh:
     name: wp-hh-internal
   only:
     - master
+    
+ # deploy to live at WP-HX
+live:wp-hx:
+  extends: .deploy
+  environment:
+    name : wp-hx-live
+  only:
+    - master
+
+# deploy to live at WP-HL
+live:wp-hl:
+  extends: .deploy
+  environment:
+    name : wp-hh-live
+  only:
+    - master


### PR DESCRIPTION
Deploy thoas to live site 2020.ensembl.org 
The added job will deploy thoas to Webteam's Kubernetes cluster at HL/HX