### PR TITLE
Suppress errors when resolving external references

### DIFF
--- a/common/crossrefs.py
+++ b/common/crossrefs.py
@@ -177,15 +177,19 @@ class XrefResolver():
         Called in map functions, to mutate an xref into a better xref
         '''
 
-        xref['url'] = self.url_from_ens_dbname(
-            xref['accession_id'],
-            xref['source']['id']
-        )
-        xref['source']['url'] = self.source_url_generator(
-            self.translate_dbname(xref['source']['id'])
-        )
-        xref['assignment_method']['description'] = self.describe_info_type(xref['assignment_method']['type'])
-        return xref
+        try:
+            xref['url'] = self.url_from_ens_dbname(
+                xref['accession_id'],
+                xref['source']['id']
+            )
+            xref['source']['url'] = self.source_url_generator(
+                self.translate_dbname(xref['source']['id'])
+            )
+            xref['assignment_method']['description'] = self.describe_info_type(xref['assignment_method']['type'])
+            return xref
+        except:
+            # probably log the error somewhere; just don't send it to the client
+            return None
 
 
     def describe_info_type(self, info_type):

--- a/graphql_service/resolver/gene_model.py
+++ b/graphql_service/resolver/gene_model.py
@@ -77,7 +77,9 @@ def insert_crossref_urls(feature, info):
     '''
     resolver = info.context['XrefResolver']
     xrefs = feature['external_references']
-    return list(map(resolver.annotate_crossref, xrefs))
+    annotated_xrefs = map(resolver.annotate_crossref, xrefs) # might contain None values due to caught exceptions
+    xrefs_with_nulls_removed = filter(lambda x: x is not None, annotated_xrefs)
+    return list(xrefs_with_nulls_removed)
 
 @QUERY_TYPE.field('transcript')
 def resolve_transcript(_, info, bySymbol=None, byId=None):


### PR DESCRIPTION
Resolving external references is a tricky business. It may fail. But even when some xrefs fail to be properly resolved, the graphql server should gracefully handle the errors, skip over the failed xref, and not include the record of the error in the response. 

This should address the most pressing frontend concerns from https://www.ebi.ac.uk/panda/jira/browse/EA-683

**Before the fix** (a large blank space where the frontend doesn't render anything because of the errors and the null value for the product in the response):

![image](https://user-images.githubusercontent.com/6834224/110978873-ce387080-835b-11eb-96c6-fb29aeaa0526.png)

**After the fix** (the frontend is quite happy to render the response without the few defective xrefs):

![image](https://user-images.githubusercontent.com/6834224/110979010-fc1db500-835b-11eb-9614-3b7762f0296b.png)
