### PR TITLE
Resolve transcript tests

### DIFF
--- a/graphql_service/resolver/gene_model.py
+++ b/graphql_service/resolver/gene_model.py
@@ -278,16 +278,31 @@ class FieldNotFoundError(GraphQLError):
         super().__init__(message, extensions=self.extensions)
 
 
-class GeneNotFoundError(FieldNotFoundError):
+class FeatureNotFoundError(FieldNotFoundError):
+    '''
+    Custom error to be raised if a gene or transcript cannot be found by id
+    '''
+    def __init__(self, feature_type, bySymbol=None, byId=None):
+        if bySymbol:
+            super().__init__(feature_type, {"symbol": bySymbol['symbol'], "genome_id": bySymbol['genome_id']})
+        if byId:
+            super().__init__(feature_type, {"stable_id": byId['stable_id'], "genome_id": byId['genome_id']})
+
+
+class GeneNotFoundError(FeatureNotFoundError):
     '''
     Custom error to be raised if gene is not found
     '''
-    
     def __init__(self, bySymbol=None, byId=None):
-        if bySymbol:
-            super().__init__("gene", {"symbol": bySymbol['symbol'], "genome_id": bySymbol['genome_id']})
-        if byId:
-            super().__init__("gene", {"stable_id": byId['stable_id'], "genome_id": byId['genome_id']})
+        super().__init__("gene", bySymbol, byId)
+
+
+class TranscriptNotFoundError(FeatureNotFoundError):
+    '''
+    Custom error to be raised if transcript is not found
+    '''
+    def __init__(self, bySymbol=None, byId=None):
+        super().__init__("transcript", bySymbol, byId)
 
 
 class ProductNotFoundError(FieldNotFoundError):

--- a/graphql_service/resolver/tests/test_resolvers.py
+++ b/graphql_service/resolver/tests/test_resolvers.py
@@ -157,19 +157,18 @@ def test_resolve_gene(basic_data):
     assert result['symbol'] == 'banana'
     result = None
 
-    with pytest.raises(model.GeneNotFoundError) as feature_not_found_error:
+    with pytest.raises(model.GeneNotFoundError) as gene_not_found_error:
         result = model.resolve_gene(
             None,
             basic_data,
             byId={'stable_id': 'BROKEN BROKEN BROKEN', 'genome_id': 1}
         )
     assert not result
-    assert feature_not_found_error.value.message == "Failed to find gene with stable " \
-                                                    "id 'BROKEN BROKEN BROKEN' for genome '1'"
-    assert feature_not_found_error.value.extensions['code'] == 'GENE_NOT_FOUND'
-    assert feature_not_found_error.value.extensions['stable_id'] == 'BROKEN BROKEN BROKEN'
-    assert feature_not_found_error.value.extensions['genome_id'] == 1
-    feature_not_found_error = None
+    assert gene_not_found_error.value.message == 'Failed to find gene with ids: stable_id=BROKEN BROKEN BROKEN, genome_id=1'
+    assert gene_not_found_error.value.extensions['code'] == 'GENE_NOT_FOUND'
+    assert gene_not_found_error.value.extensions['stable_id'] == 'BROKEN BROKEN BROKEN'
+    assert gene_not_found_error.value.extensions['genome_id'] == 1
+    gene_not_found_error = None
 
     # Check unversioned query resolves as well
     result = model.resolve_gene(
@@ -193,17 +192,17 @@ def test_resolve_gene_by_symbol(basic_data):
     assert result[0]['symbol'] == 'banana'
     result = None
 
-    with pytest.raises(model.GeneNotFoundError) as feature_not_found_error:
+    with pytest.raises(model.GeneNotFoundError) as gene_not_found_error:
         result = model.resolve_genes(
             None,
             basic_data,
             bySymbol={'symbol': 'very not here', 'genome_id': 1}
         )
     assert not result
-    assert feature_not_found_error.value.message == "Failed to find gene with symbol 'very not here' for genome '1'"
-    assert feature_not_found_error.value.extensions['code'] == 'GENE_NOT_FOUND'
-    assert feature_not_found_error.value.extensions['symbol'] == 'very not here'
-    assert feature_not_found_error.value.extensions['genome_id'] == 1
+    assert gene_not_found_error.value.message == "Failed to find gene with ids: symbol=very not here, genome_id=1"
+    assert gene_not_found_error.value.extensions['code'] == 'GENE_NOT_FOUND'
+    assert gene_not_found_error.value.extensions['symbol'] == 'very not here'
+    assert gene_not_found_error.value.extensions['genome_id'] == 1
 
 def test_resolve_transcript_by_id(transcript_data):
     'Test fetching of transcripts by stable ID'
@@ -218,18 +217,17 @@ def test_resolve_transcript_by_id(transcript_data):
 
 def test_resolve_transcript_by_id_not_found(transcript_data):
     result = None
-    with pytest.raises(model.TranscriptNotFoundError) as feature_not_found_error:
+    with pytest.raises(model.TranscriptNotFoundError) as transcript_not_found_error:
         result = model.resolve_transcript(
             None,
             transcript_data,
             byId={'stable_id': 'FAKEYFAKEYFAKEY', 'genome_id': 1}
         )
     assert not result
-    assert feature_not_found_error.value.message == "Failed to find transcript with stable " \
-                                                    "id 'FAKEYFAKEYFAKEY' for genome '1'"
-    assert feature_not_found_error.value.extensions['code'] == 'TRANSCRIPT_NOT_FOUND'
-    assert feature_not_found_error.value.extensions['stable_id'] == 'FAKEYFAKEYFAKEY'
-    assert feature_not_found_error.value.extensions['genome_id'] == 1
+    assert transcript_not_found_error.value.message == "Failed to find transcript with ids: stable_id=FAKEYFAKEYFAKEY, genome_id=1"
+    assert transcript_not_found_error.value.extensions['code'] == 'TRANSCRIPT_NOT_FOUND'
+    assert transcript_not_found_error.value.extensions['stable_id'] == 'FAKEYFAKEYFAKEY'
+    assert transcript_not_found_error.value.extensions['genome_id'] == 1
 
 def test_resolve_transcript_by_symbol(transcript_data):
     'Test fetching of transcripts by symbol'
@@ -242,17 +240,16 @@ def test_resolve_transcript_by_symbol(transcript_data):
 
 def test_resolve_transcript_by_symbol_not_found(transcript_data):
     result = None
-    with pytest.raises(model.TranscriptNotFoundError) as feature_not_found_error:
+    with pytest.raises(model.TranscriptNotFoundError) as transcript_not_found_error:
         result = model.resolve_transcript(
             None,
             transcript_data,
             bySymbol={'symbol': 'some not existing symbol', 'genome_id': 1}
         )
-    assert feature_not_found_error.value.message == "Failed to find transcript with symbol " \
-                                                    "'some not existing symbol' for genome '1'"
-    assert feature_not_found_error.value.extensions['code'] == 'TRANSCRIPT_NOT_FOUND'
-    assert feature_not_found_error.value.extensions['symbol'] == 'some not existing symbol'
-    assert feature_not_found_error.value.extensions['genome_id'] == 1
+    assert transcript_not_found_error.value.message == 'Failed to find transcript with ids: symbol=some not existing symbol, genome_id=1'
+    assert transcript_not_found_error.value.extensions['code'] == 'TRANSCRIPT_NOT_FOUND'
+    assert transcript_not_found_error.value.extensions['symbol'] == 'some not existing symbol'
+    assert transcript_not_found_error.value.extensions['genome_id'] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
We have errors for missing gene, slice, and region, but not transcripts.  This change fixes that gap.

While working on this I noticed a bug in the `resolve_transcript` method for getting transcripts by symbol.  `resolve_transcript` was querying by `name`, but the key we use in MongoDB is `symbol`, not `name`: https://github.com/Ensembl/ensembl-thoas/blob/e2bd5ad9305791a8b19c9162753ccb3f777a4d50/scripts/load_genes.py#L248

https://www.ebi.ac.uk/panda/jira/browse/EA-801

