### PR TITLE
Freeze Deploy on master branch when activated

### DIFF
--- a/web/web-gitlab-ci.yml
+++ b/web/web-gitlab-ci.yml
@@ -31,12 +31,10 @@ variables:
 
   script:
     - sed -i "s#<DOCKER_IMAGE>#${DOCKER_IMAGE}#g" web/k8s/thoas_deployment.yaml
-    - echo $CI_DEPLOY_FREEZE
-    - echo "DEPLOY FREEZE JOB COMPLETED"
-    # - kubectl apply -f web/k8s/thoas_deployment.yaml
+    - kubectl apply -f web/k8s/thoas_deployment.yaml
   
   rules:
-    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "freeze-web-deploy"'
+    - if: '$CI_DEPLOY_FREEZE == null && $CI_COMMIT_BRANCH == "master"'
 
 # Run a suite of unit and integration tests
 test:


### PR DESCRIPTION
This PR serves two purpose
1. Use rules to control when to schedule the jobs instead of only/except [rules-if](https://docs.gitlab.com/13.12/ee/ci/yaml/index.html#rulesif)
2. Use Deploy Freeze to prevent automated deployment when Deploy Freeze is set [Deploy Freeze](https://docs.gitlab.com/13.12/ee/user/project/releases/index.html#prevent-unintentional-releases-by-setting-a-deploy-freeze)

In order to minimise frequency of thoas data reloading there should be some (external) mechanism to prevent deployment to 2020 production. This PR uses the concept of Deploy Freeze & Rules available in Gitlab. The deploy freeze needs the duration, start and end  using cron syntax, to be specified using GitLab UI.

In order to enable deploy freeze follow the steps specified in the [Deploy Freeze](https://docs.gitlab.com/13.12/ee/user/project/releases/index.html#prevent-unintentional-releases-by-setting-a-deploy-freeze)

GitLab CI Concepts ( Be mindful of the Gitlab version 13.12 when referring to the doc ) :
Rules : https://docs.gitlab.com/13.12/ee/ci/yaml/index.html#rules
Rules with If : https://docs.gitlab.com/13.12/ee/ci/yaml/index.html#rulesif
Deploy Freeze : https://docs.gitlab.com/13.12/ee/user/project/releases/index.html#prevent-unintentional-releases-by-setting-a-deploy-freeze 
Crontab : https://crontab.guru

JIRA
https://www.ebi.ac.uk/panda/jira/secure/RapidBoard.jspa?rapidView=332&view=detail&selectedIssue=ENSWBSITES-1392

Note : The rules-if and Deploy Freeze has only been tested on non-master branch. Please let web know before merging this to master.