### PR TITLE
Add chromosome code filter to load_regions script

### DIFF
--- a/scripts/load_regions.py
+++ b/scripts/load_regions.py
@@ -42,6 +42,7 @@ def load_regions(config, section_name, mongo_client):
                       LEFT JOIN (SELECT seq_region_id, value FROM seq_region_attrib WHERE attrib_type_id = %s) as circular_regions
                           USING (seq_region_id)
                       WHERE species_name.meta_value = %s
+                      AND coord_system.name = 'chromosome'                      
                       LIMIT %s"""
 
     with mysql_client.cursor(dictionary=True) as cursor:


### PR DESCRIPTION
In general, we only want chromosomal information in Thoas.

### Testing
I ran the script successfully for plasmodium_falciparum, the results are in `graphql-ahc-21-10-21-a`.