### PR TITLE
Change dodgy_ingress servicePort to 8000

### DIFF
--- a/k8s/dodgy_ingress.yaml
+++ b/k8s/dodgy_ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/rewrite-target: /
+#   TODO determine Thoas rate limit policy, see https://www.ebi.ac.uk/panda/jira/browse/EA-819
 spec:
   rules:
   - http:
@@ -12,4 +13,4 @@ spec:
         - path: /
           backend:
             serviceName: thoas-server-svc
-            servicePort: 31497
+            servicePort: 8000


### PR DESCRIPTION
We appear to by running a bare-metal nginx ingress as a NodePort service.  When I run `k8s get service -n ingress` with my Kubernetes credentials pointing to the web-prod K8s cluster, I get this output:

```
NAME                                    TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)                      AGE
ingress-nginx-ingress-controller        NodePort    10.252.53.198   <none>        80:30777/TCP,443:31850/TCP   729d
ingress-nginx-ingress-default-backend   ClusterIP   10.252.78.174   <none>        80/TCP                       729d
```

See https://kubernetes.github.io/ingress-nginx/deploy/baremetal/#over-a-nodeport-service for documentation on running nginx ingress as a nodeport service.

The ingress controller NodePort service is being exposed on port 30777, and proxies to port 80.  I think that the ingress then forwards traffic from port 80 to the servicePort specified in the YAML ingress file.  You can get the port information for thoas-server-svc by running `k8s get service` (default namespace), which gives

```
NAME                  TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)           AGE
...
thoas-server-svc      NodePort    10.252.73.231    <none>        8000:31497/TCP    646d
thoas-svc             ClusterIP   10.252.99.49     <none>        40000/TCP         574d
```

Port 31497 is the port that NodePort exposes on the worker node so that external users can hit the service, while port 8000 is the service port that resources in the Kubernetes cluster should talk to.  When I applied this ingress with the port set to 8000, I can hit the Thoas service at http://hx-rke-wp-webadmin-13-worker-1.caas.ebi.ac.uk:30777/.  I experimented with adding a rate-limiting annotation to prove that hitting Thoas through this port does indeed use the ingress.

I have deleted the ingress in the web-prod k8s cluster pending approval of this PR.

If you know any way in which this ingress is 'dodgy' or a 'backdoor' compared to hitting a NodePort exposed on port 31497 please do comment...