### PR TITLE
Make ingress host-specific

### DIFF
--- a/k8s/dodgy_ingress.yaml
+++ b/k8s/dodgy_ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: ensembl-thoas-ingress-<DEPLOYMENT TAG>
+  name: ensembl-thoas-ingress-<DEPLOYMENT_TAG>
   annotations:
     # https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#rate-limiting
     # nginx.ingress.kubernetes.io/limit-rpm: "2"


### PR DESCRIPTION
We need host-based routing because Thoas and Track Hub Registry are using the same Ingress service running on the same port.  Specifying a host lets the user choose which service they want to use.

This change also includes a commented-out annotation to enable rate-limiting.

The ingress does not yet exist in the web-prod cluster.  If this change is approved I will create it in web-prod.