### PR TITLE
Fix ./Dockerfile to work with Minikube

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,9 @@ RUN pip3 install -r /app/requirements.txt -e /app/
 
 ENV PYTHONPATH=\$PYTHONPATH:/app
 
-# The file must contain MongoDB configuration. 
-# mongo.conf is not in the container by default, and this will fail
-ENV GQL_CONF=/app/mongo.conf
+EXPOSE 8000
 
-ENV WORKER_COUNT=10
-CMD uvicorn --workers $WORKER_COUNT --env GQL_CONF --host=0.0.0.0 graphql_service.server:app
+WORKDIR /app
+
+ENV WORKER_COUNT=2
+CMD uvicorn --workers $WORKER_COUNT --host=0.0.0.0 graphql_service.server:APP


### PR DESCRIPTION
The purpose of this is to create a Dockerfile that can work with Minikube.  This change
1. fixes the name of the graphql server from `app` to `APP` to match https://github.com/Ensembl/ensembl-thoas/blob/master/graphql_service/server.py#L50.  
2. exposes a port so that the container can be reached, like in the [web Dockerfile](https://github.com/Ensembl/ensembl-thoas/blob/master/web/Dockerfile.web#L11)
3. removes the GQL_CONF environment variable because it causes an error.
4. changes the number of workers from 10 to 2.

Thoas Minikube documentation is at https://www.ebi.ac.uk/seqdb/confluence/display/EA/Thoas+Docs#ThoasDocs-Minikube