### PR TITLE
Fix authentication for mongoDB with pyMongo-4.0.1

### DIFF
--- a/common/mongo.py
+++ b/common/mongo.py
@@ -49,9 +49,10 @@ class MongoDbClient:
         client = pymongo.MongoClient(
             host,
             port,
+            username=user,
+            password=password,
             read_preference=pymongo.ReadPreference.SECONDARY_PREFERRED
         )
-        client.admin.authenticate(user, password)
         print('connected to MongoDB ' + host)
         return client[dbname]
 


### PR DESCRIPTION
pyMongo version 4.0 onwards authenticate method doesn't work it has to provide username, password along with connection details.
The PR updates the code to fix MongoDB authentication. 

Only one of the PR either [PR#56](https://github.com/Ensembl/ensembl-thoas/pull/56) or this [PR#55](https://github.com/Ensembl/ensembl-thoas/pull/55) should be merged