### PR TITLE
Fix pyMongo version to 3.12.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ ariadne
 configparser
 ijson
 mongomock
-pymongo
+pymongo==3.12.0
 pytest
 pytest-asyncio
 python-dotenv


### PR DESCRIPTION
`pip install` by default installs pyMongo version 4.0.1 which breaks initialisation of MongoDB client and it needs authentication parameters passed along with client connection as oppose to separate authenticate method. 

With this PR the pyMongo version is fixed to 3.12.0 so pip will install 3.12.0 and not 4.0.1

Only one of the PR either [PR#55](https://github.com/Ensembl/ensembl-thoas/pull/55)  or this [PR#56](https://github.com/Ensembl/ensembl-thoas/pull/56)  should be merged