### PR TITLE
Reinstate GQL_CONF in ./Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ COPY . /app
 RUN pip3 install -r /app/requirements.txt -e /app/
 
 ENV PYTHONPATH=\$PYTHONPATH:/app
+ENV GQL_CONF=/app/mongo.conf
 
 EXPOSE 8000
 


### PR DESCRIPTION
I mistakenly deleted this in https://github.com/Ensembl/ensembl-thoas/pull/52.  This environment variable is actually necessary to get the service working in Minikube.