### PR TITLE
Add DOCKER_IMAGE env variable

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,6 +18,7 @@ variables:
   # We need to disable TLS (https://about.gitlab.com/blog/2019/07/31/docker-in-docker-with-docker-19-dot-03/#disable-tls)
   # to fix the error "docker: Cannot connect to the Docker daemon at tcp://docker:2375. Is the docker daemon running?"
   DOCKER_TLS_CERTDIR: ""
+  DOCKER_IMAGE: ${CI_REGISTRY_IMAGE}:${CI_COMMIT_SHA}
 
 # Template to build docker image
 .build:


### PR DESCRIPTION
Thoas build is failing with this error: 

```
$ docker build -t ${DOCKER_IMAGE} --no-cache -f k8s/Dockerfile .
invalid argument "--no-cache" for "-t, --tag" flag: invalid reference format

```
https://gitlab.ebi.ac.uk/ensembl-apps/ensembl-thoas/-/jobs/823700

I think the issue is that the $DOCKER_IMAGE value is not being set, so this PR sets it explicitly.  I'm not sure why this variable isn't set any more, but it could be related to the fact that I changed the Gitlab default branch from `master` to `main`.