### PR TITLE
Debug should be off by default

### DIFF
--- a/graphql_service/server.py
+++ b/graphql_service/server.py
@@ -72,12 +72,12 @@ starlette_middleware = [
     Middleware(CORSMiddleware, allow_origins=["*"], allow_methods=["GET", "POST"])
 ]
 
-APP = Starlette(debug=True, middleware=starlette_middleware)
+APP = Starlette(debug=DEBUG_MODE, middleware=starlette_middleware)
 APP.mount(
     "/",
     GraphQL(
         EXECUTABLE_SCHEMA,
-        debug=True,
+        debug=DEBUG_MODE,
         context_value=CONTEXT_PROVIDER,
         extensions=EXTENSIONS,
     ),


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/EA-969

We're exposing our stack traces in production right now.  This is bad security practice, so this PR silences the debug info by default.

This change just removes the stack trace, it preserves the error message we send to the client.  For example this request:

```graphql
query {
  genes_by_symbol(bySymbol:{
    genome_id:"blah blah blah",
    symbol: "FOXP2"
  }) {
    stable_id
  }
}
```
gets this response:
```json
{
  "data": {
    "genes_by_symbol": null
  },
  "errors": [
    {
      "message": "Failed to find gene with ids: symbol=FOXP2, genome_id=blah blah blah",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "genes_by_symbol"
      ],
      "extensions": {
        "code": "GENE_NOT_FOUND",
        "symbol": "FOXP2",
        "genome_id": "blah blah blah"
      }
    }
  ]
}
```