### PR TITLE
Put release in collection name

### DIFF
--- a/scripts/multi_load.py
+++ b/scripts/multi_load.py
@@ -89,7 +89,9 @@ if __name__ == "__main__":
     CONF_PARSER.read(CLI_ARGS.config)
     validate_config(CONF_PARSER)
 
-    mongo_collection_name = get_default_collection_name(CONF_PARSER["GENERAL"]["release"])
+    mongo_collection_name = get_default_collection_name(
+        CONF_PARSER["GENERAL"]["release"]
+    )
     print(f"Dumping data to {os.getcwd()} and loading to MongoDB")
 
     # each section of the file dictates a particular assembly to work on


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/EA-1002

It will be useful to make the release number part of the collection name, otherwise there's no obvious way to tell which release a collection corresponds to.

While making this change I noticed some buggy code in how we create a name for the collection.  The current implementation creates a default collection name for every species, but we want to use the same collection name for all species.  The collection name contains a second-accurate timestamp, so if we take longer than 1 second to create all the collection names we would create multiple collections.  I guess that this bug hasn't shown up because we always take less than 1 second right now, but that could change with more species.

## Testing
Tests pass.  I ran the scripts for a config file pointing at e. coli and p. falciparum, results are at `graphql_220920160804_1916d46_104`