### PR TITLE
Create new genome-level graphql types

### DIFF
--- a/common/schemas/genome.graphql
+++ b/common/schemas/genome.graphql
@@ -1,0 +1,27 @@
+type Assembly {
+  id: String!
+  name: String!
+  accession_id: String!
+  accessioning_body: String!
+  organism: Organism!
+  regions: [Region!]!
+  default: Boolean!
+  tolid: String
+}
+
+type Organism {
+  scientific_name: String!
+  scientific_parlance_name: String
+  species: Species!
+  id: String!
+  assemblies: [Assembly!]!
+  is_reference_organism: Boolean
+}
+
+type Species {
+  scientific_name: String!
+  ncbi_common_name: String
+  alternative_names: [String!]!
+  taxon_id: Int!
+  organisms: [Organism!]!
+}

--- a/common/schemas/slice.graphql
+++ b/common/schemas/slice.graphql
@@ -56,16 +56,6 @@ enum RegionTopology {
   circular
 }
 
-type Assembly {
-  type: String!
-  default: Boolean!
-  id: String!
-  name: String!
-  accession_id: String
-  accessioning_body: String
-  species: String!
-}
-
 type Strand {
   # The direction of reading sense w.r.t. the assembly. 1 = 5'->3', -1 = 3'-5'
   code: String

--- a/graphql_service/ariadne_app.py
+++ b/graphql_service/ariadne_app.py
@@ -27,6 +27,9 @@ from graphql_service.resolver.gene_model import (
     SLICE_TYPE,
     REGION_TYPE,
     GENE_METADATA_TYPE,
+    ASSEMBLY_TYPE,
+    ORGANISM_TYPE,
+    SPECIES_TYPE,
 )
 
 
@@ -45,6 +48,9 @@ def prepare_executable_schema() -> GraphQLSchema:
         GENE_METADATA_TYPE,
         SLICE_TYPE,
         REGION_TYPE,
+        ASSEMBLY_TYPE,
+        ORGANISM_TYPE,
+        SPECIES_TYPE,
     )
 
 

--- a/graphql_service/resolver/exceptions.py
+++ b/graphql_service/resolver/exceptions.py
@@ -1,0 +1,149 @@
+from typing import Optional, Dict
+
+from graphql import GraphQLError
+
+
+class FieldNotFoundError(GraphQLError):
+    """
+    Custom error to be raised if a field cannot be found by id
+    """
+
+    def __init__(self, field_type: str, key_dict: Dict[str, str]):
+        self.extensions = {"code": f"{field_type.upper()}_NOT_FOUND"}
+        ids_string = ", ".join([f"{key}={val}" for key, val in key_dict.items()])
+        message = f"Failed to find {field_type} with ids: {ids_string}"
+        self.extensions.update(key_dict)
+        super().__init__(message, extensions=self.extensions)
+
+
+class FeatureNotFoundError(FieldNotFoundError):
+    """
+    Custom error to be raised if a gene or transcript cannot be found by id
+    """
+
+    def __init__(
+        self,
+        feature_type: str,
+        bySymbol: Optional[Dict[str, str]] = None,
+        byId: Optional[Dict[str, str]] = None,
+    ):
+        if bySymbol:
+            super().__init__(
+                feature_type,
+                {"symbol": bySymbol["symbol"], "genome_id": bySymbol["genome_id"]},
+            )
+        if byId:
+            super().__init__(
+                feature_type,
+                {"stable_id": byId["stable_id"], "genome_id": byId["genome_id"]},
+            )
+
+
+class GeneNotFoundError(FeatureNotFoundError):
+    """
+    Custom error to be raised if gene is not found
+    """
+
+    def __init__(
+        self,
+        by_symbol: Optional[Dict[str, str]] = None,
+        by_id: Optional[Dict[str, str]] = None,
+    ):
+        super().__init__("gene", by_symbol, by_id)
+
+
+class TranscriptNotFoundError(FeatureNotFoundError):
+    """
+    Custom error to be raised if transcript is not found
+    """
+
+    def __init__(
+        self,
+        by_symbol: Optional[Dict[str, str]] = None,
+        by_id: Optional[Dict[str, str]] = None,
+    ):
+        super().__init__("transcript", by_symbol, by_id)
+
+
+class ProductNotFoundError(FieldNotFoundError):
+    """
+    Custom error to be raised if product is not found
+    """
+
+    def __init__(self, product_id: str, genome_id: str):
+        super().__init__("product", {"product_id": product_id, "genome_id": genome_id})
+
+
+class RegionNotFoundError(FieldNotFoundError):
+    """
+    Custom error to be raised if region is not found
+    """
+
+    def __init__(self, region_id: str):
+        super().__init__("region", {"region_id": region_id})
+
+
+class AssemblyNotFoundError(FieldNotFoundError):
+    """
+    Custom error to be raised in assembly is not found
+    """
+
+    def __init__(self, assembly_id: str):
+        super().__init__("assembly", {"assembly_id": assembly_id})
+
+
+class RegionsFromAssemblyNotFound(FieldNotFoundError):
+    """
+    Custom error to be raised if we can't find the regions for an assembly
+    """
+
+    def __init__(self, assembly_id):
+        super().__init__("regions", {"assembly_id": assembly_id})
+
+
+class OrganismFromAssemblyNotFound(FieldNotFoundError):
+    """
+    Custom error to be raised if we can't find the organism for an assembly
+    """
+
+    def __init__(self, organism_id):
+        super().__init__("organism", {"organism_id": organism_id})
+
+
+class AssembliesFromOrganismNotFound(FieldNotFoundError):
+    """
+    Custom error to be raised if we can't find the assemblies for an organism
+    """
+
+    def __init__(self, organism_id):
+        super().__init__("assemblies", {"organism_id": organism_id})
+
+
+class SpeciesFromOrganismNotFound(FieldNotFoundError):
+    """
+    Custom error to be raised if we can't find the species for an organism
+    """
+
+    def __init__(self, species_id):
+        super().__init__("species", {"species_id": species_id})
+
+
+class OrganismsFromSpeciesNotFound(FieldNotFoundError):
+    """
+    Custom error to be raised if we can't find the organisms for a species
+    """
+
+    def __init__(self, species_id):
+        super().__init__("organisms", {"species_id": species_id})
+
+
+class SliceLimitExceededError(GraphQLError):
+    """
+    Custom error to be raised if number of slice results exceeds limit
+    """
+
+    extensions = {"code": "SLICE_RESULT_LIMIT_EXCEEDED"}
+
+    def __init__(self, max_results_size: int):
+        message = f"Slice query met size limit of {max_results_size}"
+        super().__init__(message, extensions=self.extensions)

--- a/graphql_service/resolver/tests/test_data_loaders.py
+++ b/graphql_service/resolver/tests/test_data_loaders.py
@@ -61,13 +61,15 @@ async def test_batch_transcript_load():
 
     loaders = BatchLoaders(collection)
 
-    response = await loaders.batch_transcript_load(["1_ENSG001.1"])
+    response = await loaders.batch_transcript_by_gene_load(["1_ENSG001.1"])
 
     assert len(response) == 1
     # There are two hits that match the one requested ID
     assert len(response[0]) == 2
 
-    response = await loaders.batch_transcript_load(["1_ENSG001.1", "1_ENSG002.2"])
+    response = await loaders.batch_transcript_by_gene_load(
+        ["1_ENSG001.1", "1_ENSG002.2"]
+    )
     # This broadly proves that data emerges in lists ordered
     # by the input IDs
     assert len(response) == 2
@@ -76,7 +78,7 @@ async def test_batch_transcript_load():
     assert response[1][0]["gene"] == "ENSG002.2"
 
     # Try for absent data
-    response = await loaders.batch_transcript_load(["nonsense"])
+    response = await loaders.batch_transcript_by_gene_load(["nonsense"])
 
     # No results in the structure that is returned
     assert not response[0]

--- a/graphql_service/tests/fixtures/human_brca2.py
+++ b/graphql_service/tests/fixtures/human_brca2.py
@@ -350,4 +350,26 @@ def build_assembly():
         "accession_id": "GCA_000001405.28",
         "accessioning_body": "EGA",
         "species": "homo_sapiens",
+        "organism_foreign_key": 1,
+    }
+
+
+def build_organism():
+    return {
+        "type": "Organism",
+        "scientific_name": "Homo sapiens",
+        "scientific_parlance_name": "Homo sapiens",
+        "is_reference_organism": False,
+        "organism_primary_key": 1,
+        "species_foreign_key": 1,
+    }
+
+
+def build_species():
+    return {
+        "type": "Species",
+        "scientific_name": "Homo sapiens",
+        "taxon_id": 9606,
+        "ncbi_common_name": "Human",
+        "species_primary_key": 1,
     }

--- a/graphql_service/tests/snapshot_utils.py
+++ b/graphql_service/tests/snapshot_utils.py
@@ -27,6 +27,8 @@ from graphql_service.tests.fixtures.human_brca2 import (
     build_products,
     build_region,
     build_assembly,
+    build_organism,
+    build_species,
 )
 from graphql_service.tests.fixtures.wheat import build_wheat_genes
 
@@ -51,6 +53,8 @@ def prepare_db():
     mocked_mongo_collection.insert_many(build_products())
     mocked_mongo_collection.insert_one(build_region())
     mocked_mongo_collection.insert_one(build_assembly())
+    mocked_mongo_collection.insert_one(build_organism())
+    mocked_mongo_collection.insert_one(build_species())
     mocked_mongo_collection.insert_many(build_wheat_genes())
     return context
 

--- a/graphql_service/tests/snapshots/snap_test_gene_retrieval.py
+++ b/graphql_service/tests/snapshots/snap_test_gene_retrieval.py
@@ -21,13 +21,11 @@ snapshots["test_gene_retrieval_by_id_camel_case 1"] = {
                 "code": "chromosome",
                 "topology": "linear",
                 "assembly": {
-                    "type": "Assembly",
                     "id": "GRCh38.p13",
                     "default": True,
                     "name": "GRCh38",
                     "accession_id": "GCA_000001405.28",
                     "accessioning_body": "EGA",
-                    "species": "homo_sapiens",
                 },
                 "metadata": {
                     "ontology_terms": [

--- a/graphql_service/tests/snapshots/snap_test_genome_retrieval.py
+++ b/graphql_service/tests/snapshots/snap_test_genome_retrieval.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots["test_genome_retrieval 1"] = {
+    "gene": {
+        "slice": {
+            "region": {
+                "assembly": {
+                    "name": "GRCh38",
+                    "organism": {
+                        "assemblies": [{"name": "GRCh38"}],
+                        "scientific_name": "Homo sapiens",
+                        "species": {
+                            "organisms": [{"scientific_name": "Homo sapiens"}],
+                            "scientific_name": "Homo sapiens",
+                        },
+                    },
+                    "regions": [{"name": "13"}],
+                },
+                "name": "13",
+            }
+        },
+        "symbol": "BRCA2",
+    }
+}

--- a/graphql_service/tests/test_gene_retrieval.py
+++ b/graphql_service/tests/test_gene_retrieval.py
@@ -62,13 +62,11 @@ async def test_gene_retrieval_by_id_camel_case(snapshot):
             length
             topology
             assembly {
-              type
               default
               id
               name
               accession_id
               accessioning_body
-              species
             }
             metadata {
               ontology_terms {

--- a/graphql_service/tests/test_genome_retrieval.py
+++ b/graphql_service/tests/test_genome_retrieval.py
@@ -1,0 +1,61 @@
+"""
+   See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+import pytest
+from ariadne import graphql
+
+from graphql_service.resolver.data_loaders import BatchLoaders
+from .snapshot_utils import setup_test, add_loaders_to_context
+
+executable_schema, context = setup_test()
+
+
+@pytest.mark.asyncio
+async def test_genome_retrieval(snapshot):
+    "Test `gene` query using byId camelCase"
+    query = """{
+      gene(by_id: { genome_id: "homo_sapiens_GCA_000001405_28", stable_id: "ENSG00000139618.15" }) {
+        symbol
+        slice {
+          region {
+            name
+            assembly {
+              name
+              organism {
+                scientific_name
+                assemblies {
+                  name
+                }
+                species {
+                  organisms {
+                    scientific_name
+                  }
+                  scientific_name
+                }
+              }
+              regions {
+                name
+              }
+            }
+          }
+        }
+      }
+    }"""
+
+    query_data = {"query": query}
+    (success, result) = await graphql(
+        executable_schema, query_data, context_value=add_loaders_to_context(context)
+    )
+    assert success
+    snapshot.assert_match(result["data"])

--- a/scripts/config_validator.py
+++ b/scripts/config_validator.py
@@ -22,7 +22,8 @@ def validate_config(config_parser: ConfigParser) -> None:
     """Basic function to validate Thoas config file.  The script checks that all required sections and fields exist, and
     that file path locations exist"""
     check_required_fields(
-        {"GENERAL", "MONGO DB", "REFGET DB"}, set(config_parser.sections())
+        {"GENERAL", "MONGO DB", "REFGET DB", "METADATA DB", "TAXON DB"},
+        set(config_parser.sections()),
     )
 
     for section in config_parser.sections():
@@ -38,6 +39,14 @@ def validate_config(config_parser: ConfigParser) -> None:
             }
         elif section in {"MONGO DB", "REFGET DB"}:
             required_fields = {"host", "port", "user", "password", "db"}
+        elif section in {"METADATA DB", "TAXON DB"}:
+            required_fields = {
+                "host",
+                "port",
+                "user",
+                "password",
+                "database",
+            }
         else:
             required_fields = {
                 "production_name",

--- a/scripts/load_genome.py
+++ b/scripts/load_genome.py
@@ -33,25 +33,17 @@ def load_genome_info(mongo_client, source_file):
                 f"Failed to parse genome file at {source_file} with error {error}"
             ) from error
 
-        mongo_client.collection().insert_one(
+        mongo_client.collection().update_one(
+            {"type": "Assembly", "id": doc["assembly"]["name"]},
             {
-                "type": "Assembly",
-                "default": True,
-                "id": doc["assembly"]["name"],
-                "name": doc["assembly"]["default"],
-                "accession_id": doc["assembly"]["accession"],
-                "accessioning_body": "EGA",
-                "species": doc["organism"]["name"],
-            }
-        )
-
-        mongo_client.collection().insert_one(
-            {
-                "type": "Species",
-                "id": doc["organism"]["name"],
-                "scientific_name": doc["organism"]["scientific_name"],
-                "taxon_id": doc["organism"]["species_taxonomy_id"],
-            }
+                "$set": {
+                    "default": True,
+                    "name": doc["assembly"]["default"],
+                    "accession_id": doc["assembly"]["accession"],
+                    "accessioning_body": "EGA",
+                    "species": doc["organism"]["name"],
+                }
+            },
         )
 
         # "Genome" (name to be used quietly), represents the sum of related

--- a/scripts/load_metadata.py
+++ b/scripts/load_metadata.py
@@ -1,0 +1,112 @@
+import itertools
+
+from mysql.connector import DataError
+
+import common.utils
+from common.mongo import MongoDbClient
+from common.mysql import MySQLClient
+
+
+def get_species_names(config):
+    """Gets the names of all the species in the config file"""
+    all_names = [
+        config[section].get("production_name") for section in config.sections()
+    ]
+    species_names = tuple(species_name for species_name in all_names if species_name)
+    if not species_names:
+        raise DataError("Could not find the names of any species!")
+    return species_names
+
+
+def load_metadata(config, mongo_client):
+    metadata_db_client = MySQLClient(config, "METADATA DB")
+    taxon_db_client = MySQLClient(config, "TAXON DB")
+
+    with metadata_db_client.connection.cursor(
+        dictionary=True
+    ) as meta_cursor, taxon_db_client.connection.cursor(
+        dictionary=True
+    ) as taxon_cursor:
+
+        species_names = get_species_names(config)
+
+        substitutions = ",".join(["%s"] * len(species_names))
+        organism_query = f"""
+            SELECT o.scientific_name,
+               o.scientific_parlance_name,
+               o.organism_id,
+               o.taxonomy_id,
+               ogm.is_reference
+            FROM organism o
+                 LEFT JOIN organism_group_member ogm on o.organism_id = ogm.organism_id
+            WHERE o.ensembl_name in ({substitutions})
+         """
+
+        meta_cursor.execute(organism_query, species_names)
+        organism_results = meta_cursor.fetchall()
+
+        assembly_id_query = """
+            SELECT a.name
+            from assembly a
+                     join genome g on a.assembly_id = g.assembly_id
+                     join organism o on g.organism_id = o.organism_id
+            WHERE o.organism_id = %s"""
+
+        for organism_row in organism_results:
+            meta_cursor.execute(assembly_id_query, (organism_row["organism_id"],))
+            for assembly_row in meta_cursor.fetchall():
+                mongo_client.collection().insert(
+                    {
+                        "type": "Assembly",
+                        "id": assembly_row["name"],
+                        "organism_foreign_key": organism_row["organism_id"],
+                    }
+                )
+
+            species_document = {
+                "type": "Species",
+                "scientific_name": organism_row["scientific_name"],
+                "taxon_id": organism_row["taxonomy_id"],
+                "ncbi_common_name": None,
+                "alternative_names": [],
+                "species_primary_key": organism_row["organism_id"],
+            }
+
+            taxon_query = """
+                SELECT t.name, t.name_class
+                FROM ncbi_taxonomy.ncbi_taxa_name t
+                WHERE t.taxon_id = %s
+                """
+
+            taxon_cursor.execute(taxon_query, (organism_row["taxonomy_id"],))
+            for taxon_row in taxon_cursor.fetchall():
+                if taxon_row["name"] and taxon_row["name_class"]:
+                    if taxon_row["name_class"] == "genbank common name":
+                        species_document["ncbi_common_name"] = taxon_row["name"]
+                    elif taxon_row["name_class"] == "common name":
+                        species_document["alternative_names"].append(taxon_row["name"])
+
+            organism_document = {
+                "type": "Organism",
+                "scientific_name": organism_row["scientific_name"],
+                "scientific_parlance_name": organism_row["scientific_parlance_name"],
+                "is_reference_organism": organism_row["is_reference"]
+                if organism_row["is_reference"]
+                else False,
+                "organism_primary_key": organism_row["organism_id"],
+                "species_foreign_key": organism_row["organism_id"],
+            }
+
+            # Note that we are creating one organism per species here.  In principle a species can have multiple
+            # organisms, but if this ever happens then we should create a new species table in Metadata DB.
+            mongo_client.collection().insert_one(organism_document)
+            mongo_client.collection().insert_one(species_document)
+
+
+if __name__ == "__main__":
+    ARGS = common.utils.parse_args()
+
+    CONFIG = common.utils.load_config(ARGS.config_file)
+    MONGO_COLLECTION = ARGS.mongo_collection
+    MONGO_CLIENT = MongoDbClient(CONFIG, MONGO_COLLECTION)
+    load_metadata(CONFIG, MONGO_CLIENT)


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/EA-990

This PR implements the CDM for organism, assembly, and species.  I left out OrganismGroup because that isn't populated yet in the Metadata DB.

## Summary of changes
1. The new Graphql types have corresponding resolvers, dataloaders, and tests.
2. I added a new `load_metadata.py` script that runs before all the others.  This new script runs once for the whole loading job, in contrast to the other `load_*` scripts which run once per species.  This is because some kinds of metadata, like organism, are the same for different species.
3. I changed the code which loads assemblies in `load_genome.py` to update the assembly that has already been written by `load_metadata` so we don't get a duplicate.
4. I updated the config validator to handle the metadata DB configs.

## Testing
Tests pass.  I ran the scripts for all 7 species, results are in `graphql_220922132001_b92bd8b_104`.