### PR TITLE
Add region input queries

### DIFF
--- a/common/schemas/query.graphql
+++ b/common/schemas/query.graphql
@@ -16,6 +16,8 @@ type Query {
                  start: Int @deprecated(reason: "Use `by_slice`"),
                  end: Int @deprecated(reason: "Use `by_slice`")
                  by_slice: SliceInput): Locus
+  region(by_name: RegionNameInput!): Region
+  regions(by_genome_id: GenomeIdInput!): [Region]
 }
 
 input SymbolInput {
@@ -39,4 +41,13 @@ type Locus {
   # A dynamically defined part of a Region
   genes: [Gene!]!
   transcripts: [Transcript!]!
+}
+
+input RegionNameInput  {
+  genome_id: String!
+  name: String!
+}
+
+input GenomeIdInput {
+  genome_id: String!
 }

--- a/graphql_service/resolver/exceptions.py
+++ b/graphql_service/resolver/exceptions.py
@@ -74,13 +74,29 @@ class ProductNotFoundError(FieldNotFoundError):
         super().__init__("product", {"product_id": product_id, "genome_id": genome_id})
 
 
+class RegionFromSliceNotFoundError(FieldNotFoundError):
+    """Custom error to be raised if we can't find the region for a slice"""
+
+    def __init__(self, region_id: str):
+        super().__init__("region", {"region_id": region_id})
+
+
 class RegionNotFoundError(FieldNotFoundError):
     """
     Custom error to be raised if region is not found
     """
 
-    def __init__(self, region_id: str):
-        super().__init__("region", {"region_id": region_id})
+    def __init__(self, genome_id: str, name: str):
+        super().__init__("region", {"genome_id": genome_id, "name": name})
+
+
+class RegionsNotFoundError(FieldNotFoundError):
+    """
+    Custom error to be raised if regions are not found
+    """
+
+    def __init__(self, genome_id: str):
+        super().__init__("regions", {"genome_id": genome_id})
 
 
 class AssemblyNotFoundError(FieldNotFoundError):

--- a/graphql_service/resolver/tests/test_resolvers.py
+++ b/graphql_service/resolver/tests/test_resolvers.py
@@ -127,11 +127,15 @@ def fixture_region_data():
                 "type": "Region",
                 "region_id": "plasmodium_falciparum_GCA_000002765_2_13",
                 "name": "13",
+                "genome_id": "plasmodium_falciparum_GCA_000002765_2",
+                "code": "chromosome",
             },
             {
                 "type": "Region",
                 "region_id": "plasmodium_falciparum_GCA_000002765_2_14",
                 "name": "14",
+                "genome_id": "plasmodium_falciparum_GCA_000002765_2",
+                "code": "chromosome",
             },
         ]
     )
@@ -475,7 +479,7 @@ async def test_resolve_region_happy_case(region_data):
         "default": True,
     }
     info = create_info(region_data)
-    result = await model.resolve_region(slc, info)
+    result = await model.resolve_region_from_slice(slc, info)
     assert result["region_id"] == "plasmodium_falciparum_GCA_000002765_2_13"
 
 
@@ -486,8 +490,8 @@ async def test_resolve_region_region_not_exist(region_data):
         "region_id": "some_non_existing_region_id",
     }
     result = None
-    with pytest.raises(model.RegionNotFoundError) as region_error:
-        result = await model.resolve_region(slc, info)
+    with pytest.raises(model.RegionFromSliceNotFoundError) as region_error:
+        result = await model.resolve_region_from_slice(slc, info)
     assert not result
     assert region_error.value.extensions["region_id"] == "some_non_existing_region_id"
 
@@ -809,6 +813,82 @@ async def test_resolve_organisms_from_species_not_exists(genome_data):
         result = await model.resolve_organisms_from_species(species, info)
     assert not result
     assert organisms_not_found_error.value.extensions["species_id"] == "blah blah"
+
+
+@pytest.mark.asyncio
+async def test_resolve_region(region_data):
+    info = create_info(region_data)
+
+    result = await model.resolve_region(
+        None,
+        info,
+        by_name={"genome_id": "plasmodium_falciparum_GCA_000002765_2", "name": "14"},
+    )
+    assert remove_ids(result) == {
+        "genome_id": "plasmodium_falciparum_GCA_000002765_2",
+        "name": "14",
+        "region_id": "plasmodium_falciparum_GCA_000002765_2_14",
+        "code": "chromosome",
+        "type": "Region",
+    }
+
+
+@pytest.mark.asyncio
+async def test_resolve_region_no_results(region_data):
+    info = create_info(region_data)
+
+    result = None
+    with pytest.raises(model.RegionNotFoundError) as region_not_found_error:
+        result = await model.resolve_region(
+            None, info, by_name={"genome_id": "yeti_genome", "name": "14"}
+        )
+    assert not result
+    assert region_not_found_error.value.extensions == {
+        "code": "REGION_NOT_FOUND",
+        "genome_id": "yeti_genome",
+        "name": "14",
+    }
+
+
+@pytest.mark.asyncio
+async def test_resolve_regions(region_data):
+    info = create_info(region_data)
+
+    result = await model.resolve_regions(
+        None, info, by_genome_id={"genome_id": "plasmodium_falciparum_GCA_000002765_2"}
+    )
+    assert remove_ids(result) == [
+        {
+            "code": "chromosome",
+            "genome_id": "plasmodium_falciparum_GCA_000002765_2",
+            "name": "13",
+            "region_id": "plasmodium_falciparum_GCA_000002765_2_13",
+            "type": "Region",
+        },
+        {
+            "code": "chromosome",
+            "genome_id": "plasmodium_falciparum_GCA_000002765_2",
+            "name": "14",
+            "region_id": "plasmodium_falciparum_GCA_000002765_2_14",
+            "type": "Region",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_resolve_regions_no_result(region_data):
+    info = create_info(region_data)
+
+    result = None
+    with pytest.raises(model.RegionsNotFoundError) as regions_not_found_error:
+        result = await model.resolve_regions(
+            None, info, by_genome_id={"genome_id": "yeti_genome"}
+        )
+    assert not result
+    assert regions_not_found_error.value.extensions == {
+        "code": "REGIONS_NOT_FOUND",
+        "genome_id": "yeti_genome",
+    }
 
 
 def remove_ids(test_output):

--- a/graphql_service/tests/fixtures/human_brca2.py
+++ b/graphql_service/tests/fixtures/human_brca2.py
@@ -319,6 +319,7 @@ def build_region():
     return {
         "type": "Region",
         "region_id": "homo_sapiens_GCA_000001405_28_13_chromosome",
+        "genome_id": "homo_sapiens_GCA_000001405_28",
         "name": "13",
         "length": 114364328,
         "code": "chromosome",

--- a/graphql_service/tests/snapshots/snap_test_region_retrieval.py
+++ b/graphql_service/tests/snapshots/snap_test_region_retrieval.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots["test_region_retrieval_by_name 1"] = {
+    "region": {"code": "chromosome", "length": 114364328, "name": "13"}
+}
+
+snapshots["test_regions_retrieval_by_genome_id 1"] = {
+    "regions": [{"code": "chromosome", "length": 114364328, "name": "13"}]
+}

--- a/graphql_service/tests/test_region_retrieval.py
+++ b/graphql_service/tests/test_region_retrieval.py
@@ -1,0 +1,56 @@
+"""
+   See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+import pytest
+from ariadne import graphql
+
+from .snapshot_utils import setup_test, add_loaders_to_context
+
+executable_schema, context = setup_test()
+
+
+@pytest.mark.asyncio
+async def test_region_retrieval_by_name(snapshot):
+    query = """{
+      region (by_name: {genome_id: "homo_sapiens_GCA_000001405_28", name: "13"}) {
+        name
+        code
+        length
+      }
+    }"""
+
+    query_data = {"query": query}
+    (success, result) = await graphql(
+        executable_schema, query_data, context_value=add_loaders_to_context(context)
+    )
+    assert success
+    snapshot.assert_match(result["data"])
+
+
+@pytest.mark.asyncio
+async def test_regions_retrieval_by_genome_id(snapshot):
+    query = """{
+      regions (by_genome_id: {genome_id: "homo_sapiens_GCA_000001405_28"}) {
+        name
+        code
+        length
+      }
+    }
+    """
+    query_data = {"query": query}
+    (success, result) = await graphql(
+        executable_schema, query_data, context_value=add_loaders_to_context(context)
+    )
+    assert success
+    snapshot.assert_match(result["data"])


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/EA-1016
https://www.ebi.ac.uk/panda/jira/browse/EA-1018
https://www.ebi.ac.uk/panda/jira/browse/EA-1017

This PR adds region input queries, associated exceptions, and tests.

Mypy, Pylint, and Pytest all pass.

This is a draft because we cannot push it until we have updated the loading scripts populate regions with genome_ids.
