### PR TITLE
Add explicit port number for nodePort service

### DIFF
--- a/k8s/web-prod/thoas_service_node.yaml
+++ b/k8s/web-prod/thoas_service_node.yaml
@@ -13,3 +13,4 @@ spec:
     - port: 8000
       protocol: TCP
       targetPort: 8000
+      nodePort: 30152


### PR DESCRIPTION
It will be useful to have a stable port number for the nodePort service so that we don't have to update links if we re-create the service.