### PR TITLE
Add region input queries

### DIFF
--- a/common/schemas/query.graphql
+++ b/common/schemas/query.graphql
@@ -16,6 +16,7 @@ type Query {
                  start: Int @deprecated(reason: "Use `by_slice`"),
                  end: Int @deprecated(reason: "Use `by_slice`")
                  by_slice: SliceInput): Locus
+  region(by_name: RegionNameInput!): Region
 }
 
 input SymbolInput {
@@ -39,4 +40,9 @@ type Locus {
   # A dynamically defined part of a Region
   genes: [Gene!]!
   transcripts: [Transcript!]!
+}
+
+input RegionNameInput  {
+  genome_id: String!
+  name: String!
 }

--- a/graphql_service/resolver/exceptions.py
+++ b/graphql_service/resolver/exceptions.py
@@ -74,13 +74,20 @@ class ProductNotFoundError(FieldNotFoundError):
         super().__init__("product", {"product_id": product_id, "genome_id": genome_id})
 
 
+class RegionFromSliceNotFoundError(FieldNotFoundError):
+    """Custom error to be raised if we can't find the region for a slice"""
+
+    def __init__(self, region_id: str):
+        super().__init__("region", {"region_id": region_id})
+
+
 class RegionNotFoundError(FieldNotFoundError):
     """
     Custom error to be raised if region is not found
     """
 
-    def __init__(self, region_id: str):
-        super().__init__("region", {"region_id": region_id})
+    def __init__(self, genome_id: str, name: str):
+        super().__init__("region", {"genome_id": genome_id, "name": name})
 
 
 class AssemblyNotFoundError(FieldNotFoundError):

--- a/graphql_service/tests/fixtures/human_brca2.py
+++ b/graphql_service/tests/fixtures/human_brca2.py
@@ -320,6 +320,7 @@ def build_region():
     return {
         "type": "Region",
         "region_id": "homo_sapiens_GCA_000001405_28_13_chromosome",
+        "genome_id": "homo_sapiens_GCA_000001405_28",
         "name": "13",
         "length": 114364328,
         "code": "chromosome",

--- a/graphql_service/tests/snapshots/snap_test_region_retrieval.py
+++ b/graphql_service/tests/snapshots/snap_test_region_retrieval.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# snapshottest: v1 - https://goo.gl/zC4yUc
+from __future__ import unicode_literals
+
+from snapshottest import Snapshot
+
+
+snapshots = Snapshot()
+
+snapshots["test_region_retrieval_by_name 1"] = {
+    "region": {"code": "chromosome", "length": 114364328, "name": "13"}
+}

--- a/graphql_service/tests/test_region_retrieval.py
+++ b/graphql_service/tests/test_region_retrieval.py
@@ -1,0 +1,38 @@
+"""
+   See the NOTICE file distributed with this work for additional information
+   regarding copyright ownership.
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+
+import pytest
+from ariadne import graphql
+
+from .snapshot_utils import setup_test, add_loaders_to_context
+
+executable_schema, context = setup_test()
+
+
+@pytest.mark.asyncio
+async def test_region_retrieval_by_name(snapshot):
+    query = """{
+      region (by_name: {genome_id: "homo_sapiens_GCA_000001405_28", name: "13"}) {
+        name
+        code
+        length
+      }
+    }"""
+
+    query_data = {"query": query}
+    (success, result) = await graphql(
+        executable_schema, query_data, context_value=add_loaders_to_context(context)
+    )
+    assert success
+    snapshot.assert_match(result["data"])


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/EA-1016
https://www.ebi.ac.uk/panda/jira/browse/EA-1018

This adds an input query which allows use to look up regions by genome id and name.  Here is an example query:
```query {
  region(by_name: {genome_id: "a73356e1-93e7-11ec-a39d-005056b38ce3", name: "2"}) {
    name
    code
    sequence {
      alphabet {
        accession_id
        label
        value
        definition
        description
      }
      checksum
    }
  }
}
```
You can test this against the Mongo collection `graphql_221116094426_a9b0b7b_104`.

This should only be merged after loading scripts have been updated: https://github.com/Ensembl/ensembl-core-mongodb-loading/pull/9