### PR TITLE
Extract debug_mode into a separate env variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7.9-slim-stretch as build
 # Contains relevant basics for Python, like GCC and similar by default
-LABEL maintainer="ktaylor@ebi.ac.uk"
+LABEL maintainer="ahc@ebi.ac.uk"
 
 COPY . /app
 

--- a/graphql_service/server.py
+++ b/graphql_service/server.py
@@ -36,16 +36,15 @@ print(os.environ)
 
 CONFIG = load_config(os.getenv("GQL_CONF"))
 
-DEBUG_MODE = False
+DEBUG_MODE = os.getenv("DEBUG_MODE", False) == "True"
 EXTENSIONS: Optional[
     ExtensionList
 ] = None  # mypy will throw an incompatible type error without this type cast
 
 if DEBUG_MODE:
-    # This will write MongoDB transactions to `thoas.log`
     log = logging.getLogger()
     log.setLevel(logging.DEBUG)
-    logging.basicConfig(level=logging.DEBUG, filename="thoas.log", filemode="w")
+    logging.basicConfig(level=logging.DEBUG)
 
     monitoring.register(CommandLogger(log))
 

--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7.9-slim-stretch as build
 # Contains relevant basics for Python, like GCC and similar by default
-LABEL maintainer="ktaylor@ebi.ac.uk"
+LABEL maintainer="ahc@ebi.ac.uk"
 
 COPY . /app
 

--- a/k8s/embassy/thoas_deployment.yaml
+++ b/k8s/embassy/thoas_deployment.yaml
@@ -21,12 +21,9 @@ spec:
           ports:
             - containerPort: 8000
           imagePullPolicy: Always
-          env:
-            - name: GQL_CONF
-              valueFrom:
-                configMapKeyRef:
-                  name: mongo-conf-filepath-cm
-                  key: GQL_CONF
+          envFrom:
+            - configMapRef:
+                name: thoas-config-location
           command: ["uvicorn"]
           args: [
             "--host",

--- a/k8s/embassy/thoas_env_variables_cm.yaml
+++ b/k8s/embassy/thoas_env_variables_cm.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 data:
   GQL_CONF: /conf/mongo.conf
+  DEBUG_MODE: "False"
 kind: ConfigMap
 metadata:
   name: mongo-conf-filepath-cm

--- a/k8s/web-prod/thoas_deployment.yaml
+++ b/k8s/web-prod/thoas_deployment.yaml
@@ -21,17 +21,9 @@ spec:
           ports:
             - containerPort: 8000
           imagePullPolicy: Always
-          env:
-            - name: GQL_CONF
-              valueFrom:
-                configMapKeyRef:
-                  name: thoas-config-location
-                  key: GQL_CONF
-            - name: HTTPS_PROXY
-              valueFrom:
-                configMapKeyRef:
-                  name: thoas-config-location
-                  key: HTTPS_PROXY
+          envFrom:
+            - configMapRef:
+                name: thoas-config-location
           command: ["uvicorn"]
           args: [
             "--host",

--- a/k8s/web-prod/thoas_env_variables_cm.yaml
+++ b/k8s/web-prod/thoas_env_variables_cm.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 data:
   GQL_CONF: /conf/mongo.conf
+  DEBUG_MODE: "False"
   HTTP_PROXY: http://hh-wwwcache.ebi.ac.uk:3128
   HTTPS_PROXY: http://hh-wwwcache.ebi.ac.uk:3128
   http_proxy: http://hh-wwwcache.ebi.ac.uk:3128

--- a/web/k8s/thoas_cm.yaml
+++ b/web/k8s/thoas_cm.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 data:
   GQL_CONF: /conf/mongo.conf
+  DEBUG_MODE: "False"
   HTTP_PROXY: http://hx-wwwcache.ebi.ac.uk:3128
   HTTPS_PROXY: https://hx-wwwcache.ebi.ac.uk:3128
   http_proxy: http://hx-wwwcache.ebi.ac.uk:3128

--- a/web/k8s/thoas_deployment.yaml
+++ b/web/k8s/thoas_deployment.yaml
@@ -17,17 +17,9 @@ spec:
           ports:
             - containerPort: 8000
           imagePullPolicy: Always
-          env:
-            - name: GQL_CONF
-              valueFrom:
-                configMapKeyRef:
-                  name: thoas-config-location
-                  key: GQL_CONF
-            - name: HTTPS_PROXY
-              valueFrom:
-                configMapKeyRef:
-                  name: thoas-config-location
-                  key: HTTPS_PROXY
+          envFrom:
+            - configMapRef:
+                name: thoas-config-location
           command: ["uvicorn"]
           args: [
             "--host",


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/EA-1034

When developing Thoas, it's annoying to have to change the DEBUG_MODE variable to True, and then remember to change it back before you push.  This PR extracts DEBUG_MODE to an environment variable, so I can easily change it locally without changing the code.

I've also changed the CommandLogger to log to std error rather than a log file, because it's easer in k8s to view std error than a log file.

I've tested these changes in Minikube and in the apps Thoas instance.