### PR TITLE
Fix Github actions workflow

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -27,10 +27,10 @@ jobs:
         uses: actions/checkout@v3
 
       # Set up Python version
-      - name: Set up Python 3.7.6
+      - name: Set up Python 3.7
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.7'
 
       # Runs a set of commands installing Python dependencies using the runners shell (Run a multi-line script)
       - name: Install Python dependencies


### PR DESCRIPTION
Github workflow actions are currently failing.  Omitting the patch number from the Python version seems to fix it.
I also upgraded checkout and setup-python versions according to https://github.com/actions/setup-python#basic-usage.