### PR TITLE
Remove sequence_checksum from intron

### DIFF
--- a/common/schemas/transcript.graphql
+++ b/common/schemas/transcript.graphql
@@ -72,7 +72,6 @@ type Intron {
   slice: Slice!
   so_term: String!
   relative_location: Location!
-  sequence_checksum: String!
 }
 
 type ProductGeneratingContext {


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/EA-1064

### Changes
Remove `sequence_checksum` from intron.

### Related commit in the loading script
https://github.com/Ensembl/ensembl-core-mongodb-loading/pull/13/commits/7935df9dd820c41e278868180e13133bc3a0599a