### PR TITLE
Fix NCBI transcript id in the schema (EA-1071)

### DIFF
--- a/common/schemas/metadata.graphql
+++ b/common/schemas/metadata.graphql
@@ -41,7 +41,7 @@ type TranscriptTSLMetadata implements ValueSetMetadata {
 }
 
 type NCBITranscript {
-	id: String!
+	ncbi_id: String!
 	url : String!
 }
 


### PR DESCRIPTION
https://www.ebi.ac.uk/panda/jira/browse/EA-1071

### Issue:
The script picks up the NCBI ID (e.g: `NM_000059.4`) from `*_attrib.csv` files and processes it fine, however, it disappears during the loading process which I assume is related to it being called id (my assumption is that Mongo doesn't like it)

### Fix
Renaming NCBI `id` field to `ncbi_id` fixed it

### Example query

```
{
  gene(
    by_id: {
      genome_id: "a7335667-93e7-11ec-a39d-005056b38ce3"
      stable_id: "ENSG00000139618"
    }
  ) {
    stable_id
    unversioned_stable_id
    transcripts {
      stable_id
      metadata {
        mane {
          value
          label
          ncbi_transcript {
            ncbi_id
            url
          }
        }
      }
    }
  }
}
```

> Collection: `graphql_230319112632_166af8e_108`