### PR TITLE
Fix mypy errors

### DIFF
--- a/graphql_service/resolver/gene_model.py
+++ b/graphql_service/resolver/gene_model.py
@@ -70,6 +70,9 @@ def resolve_gene(
             "You must provide 'by_id' or 'byId' (deprecated) argument."
         )
 
+    # this is needed for mypy to pass
+    assert by_id
+
     query = {
         "type": "Gene",
         "$or": [
@@ -187,6 +190,9 @@ def resolve_transcript(
             )
         # or in case they provided both, ask them to provide one only
         raise InputFieldArgumentNumberError(1)
+
+    # this is needed for mypy to pass
+    assert by_id or by_symbol
 
     query: Dict[str, Any] = {"type": "Transcript"}
     genome_id = None
@@ -335,6 +341,9 @@ def resolve_overlap(
             "You must provide 'by_slice' or all four 'genomeId' (deprecated), 'regionName' (deprecated), 'start' (deprecated) and 'end' (deprecated) arguments."
         )
 
+    # this is needed for mypy to pass
+    assert genome_id and region_name and start and end
+
     # Thoas only contains "chromosome"-type regions
     region_id = "_".join([genome_id, region_name, "chromosome"])
     return {
@@ -408,6 +417,9 @@ def resolve_product_by_id(
         raise MissingArgumentException(
             "You must provide 'by_id' or both 'genome_id' (deprecated) and 'stable_id' (deprecated) arguments."
         )
+
+    # this is needed for mypy to pass
+    assert genome_id and stable_id
 
     query = {
         "genome_id": genome_id,


### PR DESCRIPTION
### Changes/context

##### Issue:
MyPy was complaining with the following errors
```
$ mypy graphql_service
graphql_service/resolver/gene_model.py:341: error: Argument 4 to "overlap_region" has incompatible type "Optional[int]"; expected "int"
graphql_service/resolver/gene_model.py:341: error: Argument 5 to "overlap_region" has incompatible type "Optional[int]"; expected "int"
graphql_service/resolver/gene_model.py:343: error: Argument 4 to "overlap_region" has incompatible type "Optional[int]"; expected "int"
graphql_service/resolver/gene_model.py:343: error: Argument 5 to "overlap_region" has incompatible type "Optional[int]"; expected "int"
graphql_service/resolver/gene_model.py:422: error: Argument 1 to "ProductNotFoundError" has incompatible type "Optional[str]"; expected "str"
graphql_service/resolver/gene_model.py:422: error: Argument 2 to "ProductNotFoundError" has incompatible type "Optional[str]"; expected "str"
Found 6 errors in 1 file (checked 29 source files)
```

That's because I removed `assert` (e.g: `assert genome_id and region_name and start and end`) lines where the code/mypy checks whether the variables exist or not before proceeding.

##### Solution:
Added the `assert` lines back.