### PR TITLE
Disable explorer-plugin

### DIFF
--- a/graphql_service/server.py
+++ b/graphql_service/server.py
@@ -156,7 +156,7 @@ class CustomExplorerGraphiQL(ExplorerGraphiQL):
             CUSTOM_GRAPHIQL_HTML,
             {
                 "title": title,
-                "enable_explorer_plugin": explorer_plugin,
+                # "enable_explorer_plugin": explorer_plugin,
                 "default_query": escape_default_query(default_query),
             },
         )

--- a/graphql_service/templates/custom_graphiql.html
+++ b/graphql_service/templates/custom_graphiql.html
@@ -137,11 +137,11 @@
 
     <script
       crossorigin
-      src="https://unpkg.com/react@17/umd/react.development.js"
+      src="https://unpkg.com/react@17/umd/react.production.min.js"
     ></script>
     <script
       crossorigin
-      src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"
+      src="https://unpkg.com/react-dom@17/umd/react-dom.production.min.js"
     ></script>
 
     <script


### PR DESCRIPTION
### JIRA Ticket
https://www.ebi.ac.uk/panda/jira/browse/EA-1092

### Changes
* Disabled explorer plugin and 
* Switch react JS from development to production (smaller in size)

### Related issue
https://github.com/graphql/graphiql/issues/3291

### Note
We have 2 options:
1. Merge this branch and keep explorer-plugin disabled for now
2. Rename `https://unpkg.com/@graphiql/plugin-explorer/dist/graphiql-plugin-explorer.umd.js` to `https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js` in `custom_graphiql.html` file -> This will break again if it's renamed in [UNPKG](https://unpkg.com/browse/@graphiql/plugin-explorer@0.1.21/dist/).