### PR TITLE
Add extra fileds to Genome gRPC response

### DIFF
--- a/common/schemas/genome.graphql
+++ b/common/schemas/genome.graphql
@@ -31,4 +31,9 @@ type Genome {
   assembly_accession: String!
   scientific_name: String!
   release_number: Float!
+  taxon_id: Int!
+  tol_id: String
+  parlance_name: String
+  genome_tag: String
+  is_reference: Boolean!
 }

--- a/graphql_service/resolver/gene_model.py
+++ b/graphql_service/resolver/gene_model.py
@@ -684,6 +684,11 @@ def create_genome_response(genome):
         "assembly_accession": genome.assembly.accession,
         "scientific_name": genome.organism.scientific_name,
         "release_number": genome.release.release_version,
+        "taxon_id": genome.taxon.taxonomy_id,
+        "tol_id": genome.assembly.tol_id,
+        "parlance_name": genome.organism.scientific_parlance_name,
+        "genome_tag": genome.assembly.url_name if not None else genome.assembly.tol_id,
+        "is_reference": genome.assembly.is_reference,
     }
     return response
 


### PR DESCRIPTION
### JIRA Ticket
https://www.ebi.ac.uk/panda/jira/browse/EA-1143

### Changes
Add extra fileds to Genome's gRPC response

### Example:
#### Before
Query:
```
query {
  genome (
    by_genome_uuid: { 
      genome_uuid:"a7335667-93e7-11ec-a39d-005056b38ce3"
    }
  ) {
    genome_id
    assembly_accession
    scientific_name
    release_number
  }
}
```
Response
```
{
  "data": {
    "genome": {
      "genome_id": "a7335667-93e7-11ec-a39d-005056b38ce3",
      "assembly_accession": "GCA_000001405.29",
      "scientific_name": "Homo sapiens",
      "release_number": 110.1
    }
  },
  "extensions": {
    "execution_time_in_seconds": 0.14
  }
}
```

#### After
Query
```
query {
  genome (
    by_genome_uuid: { 
      genome_uuid:"a7335667-93e7-11ec-a39d-005056b38ce3"
    }
  ) {
    genome_id
    assembly_accession
    scientific_name
    release_number
    taxon_id
    tol_id
    parlance_name
    genome_tag
    is_reference
  }
}
```
Response
```
{
  "data": {
    "genome": {
      "genome_id": "a7335667-93e7-11ec-a39d-005056b38ce3",
      "assembly_accession": "GCA_000001405.29",
      "scientific_name": "Homo sapiens",
      "release_number": 110.1,
      "taxon_id": 9606,
      "tol_id": "",
      "parlance_name": "Human",
      "genome_tag": "grch38",
      "is_reference": true
    }
  },
  "extensions": {
    "execution_time_in_seconds": 0.2
  }
}
```

