### PR TITLE
Upgrade `ensembl-metadata-api` and other python dependencies

### DIFF
--- a/common/db.py
+++ b/common/db.py
@@ -47,9 +47,11 @@ class MongoDbClient:
             )
 
         if grpc_response:
+            logger.debug("[get_database_conn] grpc_response: %s", grpc_response)
             # replacing '.' with '_' to avoid
             # "pymongo.errors.InvalidName: database names cannot contain the character '.'" error ¯\_(ツ)_/¯
             release_version = str(grpc_response.release_version).replace(".", "_")
+            logger.debug("[get_database_conn] release_version: %s", release_version)
             chosen_db = "release_" + release_version
 
         logger.debug("[get_database_conn] Connected to '%s' MongoDB", chosen_db)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest==7.4.4
+pytest==8.0.2
 pytest-asyncio==0.18.3
 snapshottest==0.6.0
 pylint==2.14.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ aiodataloader==0.2.1
 ariadne==0.19.1
 python-dotenv==0.19.2
 uvicorn==0.18.1
-ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@2.1.0a2
+ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@2.1.0a3
 grpcio==1.62.0
 grpcio-tools==1.62.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ aiodataloader==0.2.1
 ariadne==0.19.1
 python-dotenv==0.19.2
 uvicorn==0.18.1
-ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@2.0.0.dev2
-grpcio==1.60.0
-grpcio-tools==1.60.0
+ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@2.1.0a2
+grpcio==1.62.0
+grpcio-tools==1.62.0


### PR DESCRIPTION
~I need to upgrade `ensembl-metadata-api` to `2.1.0a3` once [this PR](https://github.com/Ensembl/ensembl-metadata-api/pull/86) is approved and tagged.~ Done