### PR TITLE
Fix broken MGI URLs

### DIFF
--- a/common/crossrefs.py
+++ b/common/crossrefs.py
@@ -120,13 +120,20 @@ class XrefResolver:
             resources = self.id_org_indexed[id_org_ns_prefix]["resources"]
             for i in resources:
                 if i["official"] is True:
-                    # the if condition below is a patch fixing the broken links mentioned in EA-1188
-                    if id_org_ns_prefix == "mgi":
-                        # https://github.com/identifiers-org/identifiers-org.github.io/issues/243#issuecomment-2129094280
-                        url = f"https://identifiers.org/{xref_acc_id}"
-                    else:
-                        url_base = i["urlPattern"]
-                        (url, _) = self.id_substitution.subn(xref_acc_id, url_base)
+                    url_base = i["urlPattern"]
+
+                    # The logic below takes care of cases where the prefix is duplicated generating a broken URL EA-1188
+                    # Extract the part of the URL after the last "/"
+                    # e.g: Extracts "MGI:" from "http://www.informatics.jax.org/accession/MGI:{$id}"
+                    url_prefix = url_base.split("/")[-1].split(":")[0].lower()
+                    # Check and strip prefix if necessary
+                    if (
+                        xref_acc_id.lower().startswith(f"{id_org_ns_prefix}:")
+                        and url_prefix == id_org_ns_prefix
+                    ):
+                        xref_acc_id = xref_acc_id[len(id_org_ns_prefix) + 1 :].lower()
+
+                    (url, _) = self.id_substitution.subn(xref_acc_id, url_base)
 
         else:
             print(f"*** {id_org_ns_prefix} namespace not in identifiers.org ***")

--- a/common/crossrefs.py
+++ b/common/crossrefs.py
@@ -120,8 +120,13 @@ class XrefResolver:
             resources = self.id_org_indexed[id_org_ns_prefix]["resources"]
             for i in resources:
                 if i["official"] is True:
-                    url_base = i["urlPattern"]
-                    (url, _) = self.id_substitution.subn(xref_acc_id, url_base)
+                    # the if condition below is a patch fixing the broken links mentioned in EA-1188
+                    if id_org_ns_prefix == "mgi":
+                        # https://github.com/identifiers-org/identifiers-org.github.io/issues/243#issuecomment-2129094280
+                        url = f"https://identifiers.org/{xref_acc_id}"
+                    else:
+                        url_base = i["urlPattern"]
+                        (url, _) = self.id_substitution.subn(xref_acc_id, url_base)
 
         else:
             print(f"*** {id_org_ns_prefix} namespace not in identifiers.org ***")


### PR DESCRIPTION
### JIRA Ticket
https://www.ebi.ac.uk/panda/jira/browse/EA-1188

### Changes
~Patch MGI link by changing the`urlPattern` from `http://www.informatics.jax.org/accession/MGI:{$id}` fetched from to identifiers.org API to `https://identifiers.org/{$id}`~

💡  **Update (for the sake of having a generic fix)**:
Patch MGI link by checking the prefix (e.g. `MGI`) duplication and patching the URL on the fly.

> This might be a temporary fix.

#### Example query
```
query Gene {
  gene(
    by_id: {genome_id: "8bce37f6-5353-4fb4-962f-f7e9a6c4303d", stable_id: "ENSMUSG00000017167"}
  ) {
    metadata {
      name {
        accession_id
        url
      }
    }
  }
}
```
##### Response before patching
```
{
  "data": {
    "gene": {
      "metadata": {
        "name": {
          "accession_id": "MGI:1858201",
          "url": "http://www.informatics.jax.org/accession/MGI:MGI:1858201"  <-- broken link
        }
      }
    }
  }
}
```

##### After
```
{
  "data": {
    "gene": {
      "metadata": {
        "name": {
          "accession_id": "MGI:1858201",
          "url": "http://www.informatics.jax.org/accession/MGI:1858201"
        }
      }
    }
  }
}
```

### Related issues
https://github.com/identifiers-org/identifiers-org.github.io/issues/243