### PR TITLE
Change the way `parent_key` value is assigned

### DIFF
--- a/graphql_service/resolver/gene_model.py
+++ b/graphql_service/resolver/gene_model.py
@@ -1026,7 +1026,7 @@ def set_db_conn_for_uuid(info, uuid):
     conn = {"db_conn": db_conn, "data_loader": BatchLoaders(db_conn)}
 
     parent_key = get_path_parent_key(info)
-    info.context.setdefault(parent_key, conn)
+    info.context[parent_key] = conn
 
 
 def get_db_conn(info):


### PR DESCRIPTION
### JIRA Ticket
https://www.ebi.ac.uk/panda/jira/browse/EA-1240

### Changes
#### Example query
```
query pig_query {
  genomes(by_keyword: { common_name: "pig" }) {
    assembly_accession
    dataset {
      dataset_id
      dataset_type
      name
      release
      release_date
      release_type
      source
      type
      version
    }
    genome_id
    genome_tag
    is_reference
    parlance_name
    release_date
    release_number
    scientific_name
    taxon_id
    tol_id
    assembly {
      accession_id
      accessioning_body
      assembly_id
      default
      name
      organism {
        is_reference_organism
        scientific_name
        scientific_parlance_name
        assemblies {
          organism {
            assemblies {
              tolid
            }
          }
        }
      }
    }
  }
}
```

This query fetches many assemblies from both `110.2` and `110.2` releases.

From [dict.setdefault](https://docs.python.org/3/library/stdtypes.html#dict.setdefault) docs: 
> If key is in the dictionary, return its value. If not, insert key with a value of default and return default. default defaults to None.

In our case, `info.context[parent_key]` was already set in the previous loop executions (e.g pointing to release `110.1` collection), which means `info.context.setdefault(parent_key, conn)` will be ignored, we need to update it if the release number changes
