### PR TITLE
Upgrade metadata to 3.2.1a1 (and other dependencies)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 -r requirements.txt
-pytest==8.0.2
+pytest==8.2.0
 pytest-asyncio==0.18.3
 snapshottest==0.6.0
 pylint==2.14.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@3.2
 grpcio==1.66.1
 grpcio-tools==1.66.1
 ensembl-utils==0.4.4
+ensembl-py==2.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 mongomock==4.0.0
 pymongo==4.6.3
 requests==2.32.0
-aiodataloader==0.2.1
+aiodataloader==0.4.0
 ariadne==0.23
-python-dotenv==0.19.2
+python-dotenv==1.0.1
 uvicorn==0.18.1
 ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@3.2.1a1
 grpcio==1.66.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 mongomock==4.0.0
 pymongo==4.6.3
-requests==2.31.0
+requests==2.32.0
 aiodataloader==0.2.1
 ariadne==0.23
 python-dotenv==0.19.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ aiodataloader==0.2.1
 ariadne==0.23
 python-dotenv==0.19.2
 uvicorn==0.18.1
-ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@2.2.0a1
-grpcio==1.62.0
-grpcio-tools==1.62.0
+ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@3.2.1a1
+grpcio==1.66.1
+grpcio-tools==1.66.1
+ensembl-utils==0.4.4


### PR DESCRIPTION
### JIRA Ticket
https://www.ebi.ac.uk/panda/jira/browse/EA-1280

### Changes
Upgraded metadata from `2.2.0a1` to `3.2.1a1` and other dependencies as well