### PR TITLE
Upgrade CI/CD python version for tests to pass

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ stages:
 
 # GitLab Dependency Proxy to get rid of Docker hub pull limit issue
 # https://docs.gitlab.com/ee/user/packages/dependency_proxy/#authenticate-within-cicd
-image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/python:3.8
+image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/python:3.10.14
 
 # This fixes "error during connect: Post http://docker:2375/v1.40/auth: dial tcp: lookup docker on 192.168.65.5:53: no such host"
 variables:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ GraphQL requires a schema (in /common) and implementation of resolver functions 
 https://www.ebi.ac.uk/seqdb/confluence/display/EA/Thoas+Docs
 
 ## Installation
-Requires Python 3.8+.  
+Requires Python 3.10+.  
 
 To install dependencies, run:
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.8
+python_version = 3.10.14
 
 [mypy-requests.*]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     version="0.1.0",
     packages=find_packages(),
     license=LICENSE_CT,
-    python_requires=">=3.8",
+    python_requires=">=3.10.14",
     package_data={
         # Make sure schema makes it to distro
         "common": ["*.graphql"]


### PR DESCRIPTION
`pip install -r requirements.txt` throws this error when trying to run tests on the CI/CD pipeline
```
ERROR: Ignored the following versions that require a different python version: 0.1.1 Requires-Python >=3.9; 0.1.2 Requires-Python >=3.9; 0.1.3 Requires-Python >=3.9; 0.2.0 Requires-Python >=3.10; 0.3.0 Requires-Python >=3.10; 0.4.0 Requires-Python >=3.10; 0.4.1 Requires-Python >=3.10; 0.4.2 Requires-Python >=3.10; 0.4.3 Requires-Python >=3.10; 0.4.4 Requires-Python >=3.10; 0.5.0 Requires-Python >=3.10; 0.5.1 Requires-Python >=3.10
ERROR: Could not find a version that satisfies the requirement ensembl-utils==0.4.4 (from versions: none)
ERROR: No matching distribution found for ensembl-utils==0.4.4
```
Because the specified version of ensembl-utils (0.4.4) requires a Python version 3.10, but we were using 3.8

This PR fixes the issue