### PR TITLE
changed behaviour to raise error instead of using default db when re…

### DIFF
--- a/common/db.py
+++ b/common/db.py
@@ -42,7 +42,7 @@ class MongoDbClient:
 
     def get_database_conn(self, grpc_model, uuid):
         grpc_response = None
-        # chosen_db = self.config.get("mongo_default_db")
+
         chosen_db = None
         # Try to connect to gRPC
         try:

--- a/common/db.py
+++ b/common/db.py
@@ -17,7 +17,10 @@ import pymongo
 import mongomock
 import grpc
 from ensembl.production.metadata.grpc import ensembl_metadata_pb2_grpc
-from graphql_service.resolver.exceptions import GenomeNotFoundError, FailedToConnectToGrpc
+from graphql_service.resolver.exceptions import (
+    GenomeNotFoundError,
+    FailedToConnectToGrpc,
+)
 
 from common.utils import process_release_version
 
@@ -49,14 +52,14 @@ class MongoDbClient:
             logger.debug(
                 "[get_database_conn] Couldn't connect to gRPC Host: %s", grpc_exp
             )
-            raise FailedToConnectToGrpc("Internal server error: Couldn't connect to gRPC Host")
-        
+            raise FailedToConnectToGrpc(
+                "Internal server error: Couldn't connect to gRPC Host"
+            )
+
         if grpc_response and grpc_response.release_version:
             chosen_db = process_release_version(grpc_response)
         else:
-            logger.warning(
-                "[get_database_conn] Release not found"
-            )
+            logger.warning("[get_database_conn] Release not found")
             raise GenomeNotFoundError({"genome_id": uuid})
 
         if chosen_db is not None:

--- a/graphql_service/resolver/exceptions.py
+++ b/graphql_service/resolver/exceptions.py
@@ -235,7 +235,8 @@ class MissingArgumentException(GraphQLError):
         super().__init__(message)
 
 
-class FailedToConnectToGrpc(grpc.RpcError):
+# class FailedToConnectToGrpc(grpc.RpcError):
+class FailedToConnectToGrpc(GraphQLError):
     """
     Exception raised when there is gRPC connection issue.
     """
@@ -246,4 +247,5 @@ class FailedToConnectToGrpc(grpc.RpcError):
         Args:
             message: The error message describing the issue.
         """
-        super().__init__(message)
+        self.extensions = {"code": "SERVER_CONNECTION_FAILED"}
+        super().__init__(message, extensions=self.extensions)

--- a/graphql_service/resolver/exceptions.py
+++ b/graphql_service/resolver/exceptions.py
@@ -235,7 +235,6 @@ class MissingArgumentException(GraphQLError):
         super().__init__(message)
 
 
-# class FailedToConnectToGrpc(grpc.RpcError):
 class FailedToConnectToGrpc(GraphQLError):
     """
     Exception raised when there is gRPC connection issue.


### PR DESCRIPTION
Thoas has the following behaviour such that when a release version is requested via the genome uuid, one of the following happens:

- If a release is found, it is returned to Thoas.
- If gRPC connection is down, a default release version is used.
- If the release is not found, a default release version is used.

The diagram below shows a clearer view of this issue

```mermaid
sequenceDiagram
    title GraphQL Core Generic Workflow
    actor User as User
    participant GraphQL_BE as GraphQL UI/Backend
    participant gRPC as gRPC Service
    participant Metadata_DB as Metadata Database
    participant Mongo_DB as Mongo Database
    
    User ->> GraphQL_BE: Sends Query Request
    GraphQL_BE ->> gRPC: Request Release Version using Genome UUID
    gRPC ->> Metadata_DB: Fetch Release Version
    Note over gRPC, Metadata_DB: Example version: 110.3

    alt gRPC Connection Success
        opt Release Found in Metadata DB
            Metadata_DB -->> gRPC: Release Found
            gRPC -->> GraphQL_BE: Return Release Version
            GraphQL_BE ->> Mongo_DB: Fetch data from Mongo
            Note over GraphQL_BE, Mongo_DB: e.g., 'release_110_3' Mongo DB
            Mongo_DB -->> User: Return Fetched Data
        end

        opt Release NOT Found in Metadata DB
            Metadata_DB -->> gRPC: Release NOT Found
            gRPC -->> GraphQL_BE: Notify Release Not Found
            GraphQL_BE -->> GraphQL_BE: Fallback to "default_mongo_db"
            Note over GraphQL_BE: Default Mongo DB used as fallback
            GraphQL_BE ->> Mongo_DB: Fetch data from default Mongo (e.g., 'release_110_1')
            Mongo_DB -->> User: Return Fallback Data
        end
    else gRPC Connection FAILED
        gRPC -->> GraphQL_BE: Connection Failed
        GraphQL_BE -->> GraphQL_BE: Fallback to "default_mongo_db"
        Note over GraphQL_BE: Using default Mongo DB due to gRPC failure
        GraphQL_BE ->> Mongo_DB: Fetch data from default Mongo (e.g., 'release_110_1')
        Mongo_DB -->> User: Return Fallback Data
    end
```

This PR adds a fix such that if a release is not found or gRPC connection is unreachable, it returns an error to the user rather than using a default db.
