### PR TITLE
added gRPC reflection to Thoas client

### DIFF
--- a/common/db.py
+++ b/common/db.py
@@ -17,7 +17,6 @@ import pymongo
 import mongomock
 import grpc
 
-# from ensembl.production.metadata.grpc import ensembl_metadata_pb2_grpc
 from yagrc import reflector as yagrc_reflector
 
 from common.utils import process_release_version
@@ -133,7 +132,6 @@ class GRPCServiceClient:
         )
 
         # bind the client and the server
-        # self.stub = ensembl_metadata_pb2_grpc.EnsemblMetadataStub(self.channel)
         self.stub = stub_class(self.channel)
 
     def get_grpc_stub(self):

--- a/common/extensions.py
+++ b/common/extensions.py
@@ -33,6 +33,5 @@ class QueryExecutionTimeExtension(Extension):
             )
             return {
                 "execution_time_in_seconds": exec_time_in_secs,
-                "metadata_api_version": utils.get_ensembl_metadata_api_version(),
             }
         return None

--- a/common/utils.py
+++ b/common/utils.py
@@ -59,21 +59,6 @@ def process_release_version(grpc_response):
     return "release_" + release_version
 
 
-def get_ensembl_metadata_api_version():
-    """
-    Get the Metadata API tag from requirement.txt file
-    """
-    version = "unknown"  # default version
-    with open("requirements.txt", "r", encoding="UTF-8") as file:
-        lines = file.readlines()
-        for line in lines:
-            if "ensembl-metadata-api" in line:
-                # Extract the tag part from the line
-                version = line.strip().split("@")[-1]
-                break
-    return version
-
-
 def check_requested_fields(info: GraphQLResolveInfo, fields: List[str]) -> List[bool]:
     """
     Check if specific fields are requested in the GraphQL query.

--- a/graphql_service/resolver/gene_model.py
+++ b/graphql_service/resolver/gene_model.py
@@ -17,7 +17,6 @@ import logging
 from typing import Dict, Optional, List, Any, Mapping
 
 from ariadne import QueryType, ObjectType
-from ensembl.production.metadata.api.models import Genome
 from graphql import GraphQLResolveInfo, GraphQLError
 from pymongo.database import Database, Collection
 
@@ -868,7 +867,7 @@ def resolve_genome(_, info: GraphQLResolveInfo, by_genome_uuid: Dict[str, str]) 
 
 
 def create_genome_response(
-    genome: Genome,
+    genome,
     dataset_data: Optional[List] = None,
     assembly_data: Optional[Mapping[Any, Any]] = None,
 ) -> Dict:

--- a/graphql_service/server.py
+++ b/graphql_service/server.py
@@ -64,7 +64,8 @@ MONGO_DB_CLIENT = db.MongoDbClient(os.environ)
 
 GRPC_SERVER = db.GRPCServiceClient(os.environ)
 GRPC_STUB = GRPC_SERVER.get_grpc_stub()
-GRPC_MODEL = grpc_model.GRPC_MODEL(GRPC_STUB)
+GRPC_REFLECTOR = GRPC_SERVER.get_grpc_reflector()
+GRPC_MODEL = grpc_model.GRPC_MODEL(GRPC_STUB, GRPC_REFLECTOR)
 
 EXECUTABLE_SCHEMA = prepare_executable_schema()
 

--- a/grpc_service/grpc_model.py
+++ b/grpc_service/grpc_model.py
@@ -1,7 +1,5 @@
 import logging
 
-# from ensembl.production.metadata.grpc import ensembl_metadata_pb2
-
 logger = logging.getLogger(__name__)
 
 
@@ -19,9 +17,7 @@ class GRPC_MODEL:  # pylint: disable=invalid-name
         request_class = self.reflector.message_class(
             "ensembl_metadata.GenomeUUIDRequest"
         )
-        # request = ensembl_metadata_pb2.GenomeUUIDRequest(
-        #     genome_uuid=genome_uuid, release_version=release_version
-        # )
+
         request = request_class(
             genome_uuid=genome_uuid, release_version=release_version
         )
@@ -59,17 +55,7 @@ class GRPC_MODEL:  # pylint: disable=invalid-name
         request_class = self.reflector.message_class(
             "ensembl_metadata.GenomeBySpecificKeywordRequest"
         )
-        # request = ensembl_metadata_pb2.GenomeBySpecificKeywordRequest(
-        #     tolid=tolid,
-        #     assembly_accession_id=assembly_accession_id,
-        #     assembly_name=assembly_name,
-        #     ensembl_name=ensembl_name,
-        #     common_name=common_name,
-        #     scientific_name=scientific_name,
-        #     scientific_parlance_name=scientific_parlance_name,
-        #     species_taxonomy_id=species_taxonomy_id,
-        #     release_version=release_version,
-        # )
+
         request = request_class(
             tolid=tolid,
             assembly_accession_id=assembly_accession_id,
@@ -91,9 +77,7 @@ class GRPC_MODEL:  # pylint: disable=invalid-name
             release_version,
         )
         request_class = self.reflector.message_class("ensembl_metadata.DatasetsRequest")
-        # request = ensembl_metadata_pb2.DatasetsRequest(
-        #     genome_uuid=genome_uuid, release_version=release_version
-        # )
+
         request = request_class(
             genome_uuid=genome_uuid, release_version=release_version
         )
@@ -104,7 +88,7 @@ class GRPC_MODEL:  # pylint: disable=invalid-name
         request_class = self.reflector.message_class(
             "ensembl_metadata.ReleaseVersionRequest"
         )
-        # request = ensembl_metadata_pb2.ReleaseVersionRequest(genome_uuid=genome_uuid)
+
         request = request_class(genome_uuid=genome_uuid)
         response = self.grpc_stub.GetReleaseVersionByUUID(request)
         return response

--- a/grpc_service/grpc_model.py
+++ b/grpc_service/grpc_model.py
@@ -1,13 +1,14 @@
 import logging
 
-from ensembl.production.metadata.grpc import ensembl_metadata_pb2
+# from ensembl.production.metadata.grpc import ensembl_metadata_pb2
 
 logger = logging.getLogger(__name__)
 
 
 class GRPC_MODEL:  # pylint: disable=invalid-name
-    def __init__(self, grpc_stub):
+    def __init__(self, grpc_stub, grpc_reflector):
         self.grpc_stub = grpc_stub
+        self.reflector = grpc_reflector
 
     def get_genome_by_genome_uuid(self, genome_uuid, release_version=None):
         logger.debug(
@@ -15,10 +16,17 @@ class GRPC_MODEL:  # pylint: disable=invalid-name
             genome_uuid,
             release_version,
         )
-        request = ensembl_metadata_pb2.GenomeUUIDRequest(
+        request_class = self.reflector.message_class(
+            "ensembl_metadata.GenomeUUIDRequest"
+        )
+        # request = ensembl_metadata_pb2.GenomeUUIDRequest(
+        #     genome_uuid=genome_uuid, release_version=release_version
+        # )
+        request = request_class(
             genome_uuid=genome_uuid, release_version=release_version
         )
         response = self.grpc_stub.GetGenomeByUUID(request)
+
         return response
 
     def get_genome_by_specific_keyword(
@@ -47,7 +55,22 @@ class GRPC_MODEL:  # pylint: disable=invalid-name
             species_taxonomy_id,
             release_version,
         )
-        request = ensembl_metadata_pb2.GenomeBySpecificKeywordRequest(
+
+        request_class = self.reflector.message_class(
+            "ensembl_metadata.GenomeBySpecificKeywordRequest"
+        )
+        # request = ensembl_metadata_pb2.GenomeBySpecificKeywordRequest(
+        #     tolid=tolid,
+        #     assembly_accession_id=assembly_accession_id,
+        #     assembly_name=assembly_name,
+        #     ensembl_name=ensembl_name,
+        #     common_name=common_name,
+        #     scientific_name=scientific_name,
+        #     scientific_parlance_name=scientific_parlance_name,
+        #     species_taxonomy_id=species_taxonomy_id,
+        #     release_version=release_version,
+        # )
+        request = request_class(
             tolid=tolid,
             assembly_accession_id=assembly_accession_id,
             assembly_name=assembly_name,
@@ -67,13 +90,21 @@ class GRPC_MODEL:  # pylint: disable=invalid-name
             genome_uuid,
             release_version,
         )
-        request = ensembl_metadata_pb2.DatasetsRequest(
+        request_class = self.reflector.message_class("ensembl_metadata.DatasetsRequest")
+        # request = ensembl_metadata_pb2.DatasetsRequest(
+        #     genome_uuid=genome_uuid, release_version=release_version
+        # )
+        request = request_class(
             genome_uuid=genome_uuid, release_version=release_version
         )
         response = self.grpc_stub.GetDatasetsListByUUID(request)
         return response
 
     def get_release_by_genome_uuid(self, genome_uuid):
-        request = ensembl_metadata_pb2.ReleaseVersionRequest(genome_uuid=genome_uuid)
+        request_class = self.reflector.message_class(
+            "ensembl_metadata.ReleaseVersionRequest"
+        )
+        # request = ensembl_metadata_pb2.ReleaseVersionRequest(genome_uuid=genome_uuid)
+        request = request_class(genome_uuid=genome_uuid)
         response = self.grpc_stub.GetReleaseVersionByUUID(request)
         return response

--- a/mypy.ini
+++ b/mypy.ini
@@ -22,3 +22,5 @@ ignore_missing_imports = True
 [mypy-ensembl.production.metadata.*]
 ignore_missing_imports = True
 
+[mypy-yagrc.*]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ grpcio-tools==1.66.1
 ensembl-utils==0.4.4
 ensembl-py==2.1.3
 yagrc==1.1.2
-ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@3.2.1a1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,9 @@ aiodataloader==0.4.0
 ariadne==0.23
 python-dotenv==1.0.1
 uvicorn==0.18.1
-ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@3.2.1a1
 grpcio==1.66.1
 grpcio-tools==1.66.1
 ensembl-utils==0.4.4
 ensembl-py==2.1.3
+yagrc==1.1.2
+ensembl-metadata-api@git+https://github.com/Ensembl/ensembl-metadata-api.git@3.2.1a1


### PR DESCRIPTION
Server reflection allows gRPC clients to dynamically query information about a gRPC server's services, methods, and message types, making it easier to explore and use services.

This PR implements gRPC reflection for the Thoas client making it no longer dependent on the ensembl-metadata-api (gRPC server).

However the "Genome" model from ensembl-metadata-api is still used by some resolver functions in Thoas so the package is still left alone in this project.