### PR TITLE
Use assembly_uuid to fetch the assemlies instead of assembly name

### DIFF
--- a/graphql_service/resolver/gene_model.py
+++ b/graphql_service/resolver/gene_model.py
@@ -826,7 +826,9 @@ def resolve_genomes(
                     # logging.debug("assembly_collection.name:", assembly_collection.name)
 
                     assembly_data = (
-                        fetch_assembly_data(assembly_collection, genome.assembly.name)
+                        fetch_assembly_data(
+                            assembly_collection, genome.assembly.assembly_uuid
+                        )
                         if is_assembly_present
                         else None
                     )
@@ -868,7 +870,7 @@ def resolve_genome(_, info: GraphQLResolveInfo, by_genome_uuid: Dict[str, str]) 
     # logging.debug("assembly_collection.name:", assembly_collection.name)
 
     assembly_data = (
-        fetch_assembly_data(assembly_collection, genome.assembly.name)
+        fetch_assembly_data(assembly_collection, genome.assembly.assembly_uuid)
         if is_assembly_present
         else None
     )


### PR DESCRIPTION
### Changes
Use assembly_uuid to fetch the assemlies instead of assembly name, after updating the `assembly_id` value in Mongo to by the UUID (example below)
![image](https://github.com/user-attachments/assets/15f7ba7f-f041-42d8-8d1c-82fd3a288aad)
