### PR TITLE
Explicitly state the graphiql version used in the template

### DIFF
--- a/graphql_service/templates/custom_graphiql.html
+++ b/graphql_service/templates/custom_graphiql.html
@@ -146,7 +146,7 @@
 
     <script
       crossorigin
-      src="https://unpkg.com/graphiql/graphiql.min.js"
+      src="https://unpkg.com/graphiql@3.3.2/graphiql.min.js"
     ></script>
 
     {% if enable_explorer_plugin %}


### PR DESCRIPTION
#### Issue:
Graphiql UI broke with the following error in the console
```
TypeError: e.useInsertionEffect is not a function
...
```
I believe this happened because the main/latest graphiql is using react 18+ while Ariadne graphiql template is still using react 17.

#### Fix
Explicitly state the `graphiql` version used in the template
