### PR TITLE
Add caching for data fetched from MongoDB

### DIFF
--- a/common/db.py
+++ b/common/db.py
@@ -26,6 +26,7 @@ from graphql_service.resolver.exceptions import (
 
 from yagrc import reflector as yagrc_reflector
 
+from bson.raw_bson import RawBSONDocument
 
 from common.utils import process_release_version
 
@@ -56,6 +57,7 @@ class MongoDbClient:
         try:
             self.cache = redis.StrictRedis(host=self.redis_host, port=self.redis_port)
             self.cache.ping()  # Check Redis connection
+            logger.info(f"[MongoDbClient] Redis caching enabled")
         except redis.RedisError as e:
             logger.warning(f"[MongoDbClient] Redis not available: {e}")
             self.cache = None
@@ -117,7 +119,7 @@ class MongoDbClient:
 
     @staticmethod
     def connect_mongo(config):
-        "Get a MongoDB connection"
+        "Create a MongoDB connection that will give us non-decoded bson documents"
 
         host = config.get("MONGO_HOST").split(",")
         port = int(config.get("MONGO_PORT"))
@@ -130,11 +132,12 @@ class MongoDbClient:
             username=user,
             password=password,
             read_preference=pymongo.ReadPreference.SECONDARY_PREFERRED,
+            document_class=RawBSONDocument,
         )
         try:
             # make sure the connection is established successfully
             client.server_info()
-            print(f"Connected to MongoDB, Host: {host}")
+            logger.info(f"Connected to MongoDB, Host: {host}")
         except Exception as exc:
             raise Exception("Connection to MongoDB failed") from exc
 

--- a/graphql_service/resolver/gene_model.py
+++ b/graphql_service/resolver/gene_model.py
@@ -1042,7 +1042,7 @@ def set_db_conn_for_uuid(info, uuid, release_version=None):
         grpc_model, uuid, release_version
     )
 
-    conn = {"db_conn": db_conn, "data_loader": BatchLoaders(db_conn)}
+    conn = {"db_conn": db_conn, "data_loader": BatchLoaders(db_conn, info.context["mongo_db_client"])}
 
     parent_key = get_path_parent_key(info)
     info.context[parent_key] = conn


### PR DESCRIPTION
This adds caching for data from MongoDB. To do this efficiently, we do not immediately decode the BSON we receive from MongoDB, since we may want to have the binary data to store it in Redis. We still need to serialize this data, since we are dealing with a list of BSON objects. To do this, we use pickle.
We re-use the existing Redis connection that we already have.

If this code is run with different Python versions, they must use the same pickle versions. Otherwise, they may not share the same cache.