### PR TITLE
Fix public ingress path fetching static files

### DIFF
--- a/graphql_service/resolver/tests/dummy_transcripts_sample.py
+++ b/graphql_service/resolver/tests/dummy_transcripts_sample.py
@@ -160,4 +160,14 @@ dummy_transcripts_sample = [
         "stable_id": "tr_stable_id_12",
         "symbol": "PrCo CDS not defined",
     },
+    {
+        "metadata": {
+            "biotype": {"label": "retained_intron", "value": "retained_intron"}
+        },
+        "relative_location": {
+            "length": 14501,
+        },
+        "stable_id": "tr_stable_id_33",  # This would be ranked before tr_stable_id_3 (sorted alphabetically)
+        "symbol": "Retained Intron",
+    },
 ]

--- a/graphql_service/resolver/tests/test_resolvers.py
+++ b/graphql_service/resolver/tests/test_resolvers.py
@@ -104,6 +104,10 @@ def fixture_transcript_data():
                         "product_type": "Protein",
                         "product_id": "ENSP001.1",
                         "product_foreign_key": "1_ENSP001.1",
+                        "cds": {  # This bit became important after we introduced transcript sorting
+                            "nucleotide_length": 1234,
+                            "protein_length": 411,
+                        },
                     }
                 ],
                 "gene_foreign_key": "1_ENSG001.1",

--- a/graphql_service/resolver/tests/test_transcript_order.py
+++ b/graphql_service/resolver/tests/test_transcript_order.py
@@ -39,6 +39,7 @@ def test_sort_prioritizes_designation_and_translation_length():
         "tr_stable_id_8",
         "tr_stable_id_12",
         "tr_stable_id_11",
+        "tr_stable_id_33",
         "tr_stable_id_3",
     ]
 

--- a/graphql_service/resolver/transcript_order.py
+++ b/graphql_service/resolver/transcript_order.py
@@ -112,11 +112,14 @@ def _transcript_value(transcript):
         relative_location = transcript.get("relative_location", {})
         transcript_length = relative_location.get("length", 0)
 
+    transcript_stable_id = transcript.get("stable_id", "")
+
     return (
         designation_value,
         biotype_value,
         int(translation_length),
         transcript_length,
+        transcript_stable_id,  # We want to sort alphabetically in case the scoring is even across two or more transcripts
     )
 
 

--- a/k8s/web-prod/overlays/public-graphql/ingress-patch.yaml
+++ b/k8s/web-prod/overlays/public-graphql/ingress-patch.yaml
@@ -7,7 +7,7 @@ spec:
     - host: beta.ensembl.org
       http:
         paths:
-          - path: /data/graphql/core/?$
+          - path: /data/graphql/core(/|$)(.*)
             pathType: ImplementationSpecific
             backend:
               service:

--- a/k8s/web-prod/overlays/public-graphql/ingress-patch.yaml
+++ b/k8s/web-prod/overlays/public-graphql/ingress-patch.yaml
@@ -2,12 +2,14 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: graphql-core-ingress
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$3
 spec:
   rules:
     - host: beta.ensembl.org
       http:
         paths:
-          - path: /data/graphql/core(/|$)(.*)
+          - path: /data/graphql(/core)?(/|$)(.*)
             pathType: ImplementationSpecific
             backend:
               service:

--- a/k8s/web-prod/overlays/public-graphql/patch.yaml
+++ b/k8s/web-prod/overlays/public-graphql/patch.yaml
@@ -11,4 +11,4 @@ spec:
           env:
             # Keeps GraphiQL static/sdl URLs under the same ingress prefix.
             - name: GRAPHIQL_BASE_PATH
-              value: /data/graphql
+              value: /data/graphql/core

--- a/k8s/web-prod/overlays/public-graphql/patch.yaml
+++ b/k8s/web-prod/overlays/public-graphql/patch.yaml
@@ -11,4 +11,4 @@ spec:
           env:
             # Keeps GraphiQL static/sdl URLs under the same ingress prefix.
             - name: GRAPHIQL_BASE_PATH
-              value: /data/graphql/core
+              value: /data/graphql


### PR DESCRIPTION
For public GraphQL: Support both `/data/graphql` and `/data/graphql/core` in public GraphQL ingress (as well as `/data/graphql/whatever-you-put-here` but that's fine for now)

I also hijacked this PR to add transcript_id to the transcript sorting algorithm