### PR TITLE
Add transcript counts for parent gene

### DIFF
--- a/common/schemas/gene.graphql
+++ b/common/schemas/gene.graphql
@@ -43,6 +43,11 @@ type Gene {
   transcripts: [Transcript!]!
 
   """
+  The total number of transcripts associated with the gene.
+  """
+  transcript_count: Int!
+
+  """
   Fetches a paginated list of transcripts associated with the gene.
   """
   transcripts_page(

--- a/graphql_service/resolver/gene_model.py
+++ b/graphql_service/resolver/gene_model.py
@@ -345,6 +345,24 @@ async def resolve_gene_transcripts(gene: Dict, info: GraphQLResolveInfo) -> List
     return sorted_transcripts
 
 
+@GENE_TYPE.field("transcript_count")
+def resolve_gene_transcript_count(gene: Dict, info: GraphQLResolveInfo) -> int:
+    "Count transcripts for the parent gene"
+    query = {
+        "type": "Transcript",
+        "gene_foreign_key": gene["gene_primary_key"],
+    }
+
+    connection_db = get_db_conn(info)
+    transcript_collection = connection_db["transcript"]
+    logger.info(
+        "[resolve_gene_transcript_count] Getting Transcript count from DB: '%s'",
+        connection_db.name,
+    )
+
+    return transcript_collection.count_documents(query)
+
+
 @GENE_TYPE.field("transcripts_page")
 async def resolve_gene_transcripts_page(
     gene: Dict, _: GraphQLResolveInfo, page: int, per_page: int

--- a/graphql_service/resolver/tests/test_resolvers.py
+++ b/graphql_service/resolver/tests/test_resolvers.py
@@ -435,6 +435,22 @@ async def test_resolve_gene_transcripts(transcript_data):
         assert hit["symbol"] in ["kumquat", "grape"]
 
 
+def test_resolve_gene_transcript_count(transcript_data):
+    "Check transcript count for a gene"
+
+    info = create_graphql_resolve_info(transcript_data)
+
+    # Finding the collection here as we are not using the base resolver
+    model.set_db_conn_for_uuid(info, "1")
+
+    result = model.resolve_gene_transcript_count(
+        {"stable_id": "ENSG001.1", "genome_id": "1", "gene_primary_key": "1_ENSG001.1"},
+        info,
+    )
+
+    assert result == 2
+
+
 @pytest.mark.asyncio
 async def test_resolve_gene_from_transcript(transcript_data):
     "Check the DataLoader for gene is working via transcript. Requires event loop for DataLoader"

--- a/graphql_service/tests/test_gene_retrieval.py
+++ b/graphql_service/tests/test_gene_retrieval.py
@@ -150,6 +150,24 @@ async def test_gene_retrieval_by_symbol(snapshot):
 
 
 @pytest.mark.asyncio
+async def test_gene_transcript_count():
+    "Test `transcript_count` on `Gene`"
+
+    query = """{
+      gene(by_id: { genome_id: "homo_sapiens_GCA_000001405_28", stable_id: "ENSG00000139618.15" }) {
+        transcript_count
+      }
+    }"""
+    query_data = {"query": query}
+
+    (success, result) = await graphql(
+        executable_schema, query_data, context_value=context()
+    )
+    assert success
+    assert result["data"]["gene"]["transcript_count"] == 2
+
+
+@pytest.mark.asyncio
 async def test_transcript_pagination(snapshot):
     """
     Run a query checking pagination


### PR DESCRIPTION
### Summary

Adds `transcript_count` to the `Gene` GraphQL type so clients can request the total number of transcripts associated with a gene without fetching the full transcript list or using transcript pagination metadata.

### Changes

- Added `transcript_count: Int!` to `common/schemas/gene.graphql`
- Added a `Gene.transcript_count` resolver that counts transcripts by `gene_foreign_key`
- Added resolver-level and GraphQL-level tests for the new field
- Added tests