### PR TITLE
Fix wheat xref urls

### DIFF
--- a/docs/xref_LOD_mapping.json
+++ b/docs/xref_LOD_mapping.json
@@ -1513,21 +1513,21 @@
         "ensembl_db_name": "KNETMINER_WHEAT",
         "feature_type": "gene",
         "manual_source_url" : "https://knetminer.com",
-        "manual_xref_url" : "https://knetminer.com/Triticum_aestivum/"
+        "manual_xref_url" : "https://app.knetminer.com/genepage/Triticum_aestivum/?list="
     },
     {
         "db_name": "WHEATEXP_GENE",
         "ensembl_db_name": "WHEATEXP_GENE",
         "feature_type": "gene",
         "manual_source_url" : "https://wheat.pw.usda.gov",
-        "manual_xref_url" : "https://wheat.pw.usda.gov/WheatExp/"
+        "manual_xref_url" : "https://www.wheat-expression.com/genes/show?gene_set=RefSeq1.1&search_by=gene&name="
     },
     {
         "db_name": "WHEATEXP_TRANS",
         "ensembl_db_name": "WHEATEXP_TRANS",
         "feature_type": "transcript",
         "manual_source_url" : "https://wheat.pw.usda.gov",
-        "manual_xref_url" : "https://wheat.pw.usda.gov/WheatExp/"
+        "manual_xref_url" : "https://www.wheat-expression.com/genes/show?gene_set=RefSeq1.1&search_by=transcript&name="
     },
     {
         "db_name": "TRNASCAN_SE",


### PR DESCRIPTION
Dare reported a while ago some broken xref URLs on beta (on the right hand side [here](https://beta.ensembl.org/entity-viewer/a73357ab-93e7-11ec-a39d-005056b38ce3/gene:TraesCS4D02G040400?view=transcripts))

This PR update the urls

Example GraphQL query that can be used to check:
```
query GeneExternalReferences {
  gene(by_id: { 
    stable_id: "TraesCS4D02G040400", 
    genome_id: "a73357ab-93e7-11ec-a39d-005056b38ce3" 
  }) {
    stable_id
    symbol
    external_references {
      accession_id
      name
      description
      url
      source {
        id
        name
      }
    }
  }
}
```

Response:

Before the fix

```
{
  "data": {
    "gene": {
      "stable_id": "TraesCS4D02G040400",
      "symbol": "RHT1",
      "external_references": [
        ...
        {
          "accession_id": "TraesCS4D02G040400",
          "name": "TraesCS4D02G040400",
          "description": null,
          "url": "https://knetminer.com/Triticum_aestivum/TraesCS4D02G040400",
          "source": {
            "id": "KNETMINER_WHEAT",
            "name": "KNETMINER_WHEAT"
          }
        },
        {
          "accession_id": "TraesCS4D02G040400",
          "name": "TraesCS4D02G040400",
          "description": null,
          "url": "https://wheat.pw.usda.gov/WheatExp/TraesCS4D02G040400",
          "source": {
            "id": "WHEATEXP_GENE",
            "name": "Wheat Expression"
          }
        }
      ]
    }
  },
  "extensions": {
    "execution_time_in_seconds": 0.01
  }
}
```

After:

```
{
  "data": {
    "gene": {
      "stable_id": "TraesCS4D02G040400",
      "symbol": "RHT1",
      "external_references": [
        ...
        {
          "accession_id": "TraesCS4D02G040400",
          "name": "TraesCS4D02G040400",
          "description": null,
          "url": "https://app.knetminer.com/genepage/Triticum_aestivum/?list=TraesCS4D02G040400",
          "source": {
            "id": "KNETMINER_WHEAT",
            "name": "KNETMINER_WHEAT"
          }
        },
        {
          "accession_id": "TraesCS4D02G040400",
          "name": "TraesCS4D02G040400",
          "description": null,
          "url": "https://www.wheat-expression.com/genes/show?gene_set=RefSeq1.1&search_by=gene&name=TraesCS4D02G040400",
          "source": {
            "id": "WHEATEXP_GENE",
            "name": "Wheat Expression"
          }
        }
      ]
    }
  },
  "extensions": {
    "execution_time_in_seconds": 0.03
  }
}
```