### PR TITLE
Add Prometheus metrics for GraphQL operations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ COPY . /app
 RUN pip3 install -r /app/requirements.txt -e /app/
 
 ENV PYTHONPATH=\$PYTHONPATH:/app
+ENV PROMETHEUS_MULTIPROC_DIR=/tmp/prometheus-multiproc
+RUN mkdir -p /tmp/prometheus-multiproc
 
 EXPOSE 8000
 

--- a/graphql_service/server.py
+++ b/graphql_service/server.py
@@ -267,7 +267,26 @@ APP = applications.Starlette(
     lifespan=lifespan,
 )
 
-Instrumentator(excluded_handlers=["/metrics"]).instrument(APP).expose(
+Instrumentator(excluded_handlers=["/metrics"]).instrument(
+    APP,
+    latency_lowr_buckets=(
+        0.01,
+        0.025,
+        0.05,
+        0.1,
+        0.25,
+        0.5,
+        1,
+        1.25,
+        1.5,
+        1.75,
+        2,
+        2.5,
+        5,
+        10,
+        30,
+    ),
+).expose(
     APP, endpoint="/metrics"
 )
 

--- a/graphql_service/server.py
+++ b/graphql_service/server.py
@@ -16,6 +16,7 @@
 
 import logging
 import os
+import time
 from contextlib import asynccontextmanager
 from typing import Optional, List
 
@@ -25,6 +26,8 @@ from ariadne.contrib.tracing.apollotracing import ApolloTracingExtension
 from ariadne.explorer import ExplorerGraphiQL, render_template, escape_default_query
 from ariadne.explorer.template import read_template
 from ariadne.types import ExtensionList
+from prometheus_client import Counter, Histogram
+from prometheus_fastapi_instrumentator import Instrumentator
 from pymongo import monitoring
 from starlette import applications
 from starlette.middleware import Middleware
@@ -61,6 +64,17 @@ EXTENSIONS: Optional[ExtensionList] = (
 
 # Including the execution time in the response
 EXTENSIONS = [extensions.QueryExecutionTimeExtension]
+
+GRAPHQL_OPERATIONS = Counter(
+    "graphql_operations_total",
+    "Total number of GraphQL operations",
+    ["operation_name", "status"],
+)
+GRAPHQL_OPERATION_DURATION = Histogram(
+    "graphql_operation_duration_seconds",
+    "GraphQL operation execution time",
+    ["operation_name"],
+)
 
 if DEBUG_MODE:
     log = logging.getLogger()
@@ -202,6 +216,40 @@ class CustomExplorerGraphiQL(
         )
 
 
+class PrometheusGraphQLHTTPHandler(GraphQLHTTPHandler):
+    """Record low overhead Prometheus metrics for GraphQL operations"""
+
+    async def execute_graphql_query(
+        self,
+        request,
+        data,
+        *,
+        context_value=None,
+        query_document=None,
+    ):
+        """Execute an operation and record its count, status, and duration."""
+        operation_name = data.get("operationName") if isinstance(data, dict) else None
+        if not isinstance(operation_name, str) or not operation_name:
+            operation_name = "anonymous"
+
+        start_time = time.perf_counter()
+        status = "error"
+        try:
+            success, result = await super().execute_graphql_query(
+                request,
+                data,
+                context_value=context_value,
+                query_document=query_document,
+            )
+            status = "success" if success else "error"
+            return success, result
+        finally:
+            GRAPHQL_OPERATIONS.labels(operation_name, status).inc()
+            GRAPHQL_OPERATION_DURATION.labels(operation_name).observe(
+                time.perf_counter() - start_time
+            )
+
+
 # https://starlette.dev/lifespan/
 @asynccontextmanager
 async def lifespan(_app):
@@ -217,6 +265,10 @@ APP = applications.Starlette(
     debug=DEBUG_MODE,
     middleware=starlette_middleware,
     lifespan=lifespan,
+)
+
+Instrumentator(excluded_handlers=["/metrics"]).instrument(APP).expose(
+    APP, endpoint="/metrics"
 )
 
 # Serve GraphiQL frontend assets (JS/CSS/examples) from this package's `static` dir.
@@ -249,7 +301,7 @@ APP.mount(
         EXECUTABLE_SCHEMA,
         debug=DEBUG_MODE,
         context_value=CONTEXT_PROVIDER,
-        http_handler=GraphQLHTTPHandler(
+        http_handler=PrometheusGraphQLHTTPHandler(
             extensions=EXTENSIONS,
         ),
         explorer=CustomExplorerGraphiQL(),

--- a/graphql_service/server.py
+++ b/graphql_service/server.py
@@ -286,9 +286,7 @@ Instrumentator(excluded_handlers=["/metrics"]).instrument(
         10,
         30,
     ),
-).expose(
-    APP, endpoint="/metrics"
-)
+).expose(APP, endpoint="/metrics")
 
 # Serve GraphiQL frontend assets (JS/CSS/examples) from this package's `static` dir.
 # Resolve from `__file__` so it works regardless of the process working directory.

--- a/graphql_service/server.py
+++ b/graphql_service/server.py
@@ -36,7 +36,7 @@ from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.middleware.gzip import GZipMiddleware
 from starlette.staticfiles import StaticFiles
 from starlette.responses import PlainTextResponse, Response
-from graphql import print_schema
+from graphql import FieldNode, GraphQLError, get_operation_ast, parse, print_schema
 
 from dotenv import load_dotenv
 from common import crossrefs, db, extensions, utils, logger
@@ -65,15 +65,34 @@ EXTENSIONS: Optional[ExtensionList] = (
 # Including the execution time in the response
 EXTENSIONS = [extensions.QueryExecutionTimeExtension]
 
-GRAPHQL_OPERATIONS = Counter(
-    "graphql_operations_total",
-    "Total number of GraphQL operations",
-    ["operation_name", "status"],
+LATENCY_BUCKETS = (
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1,
+    1.25,
+    1.5,
+    1.75,
+    2,
+    2.5,
+    5,
+    10,
+    30,
 )
-GRAPHQL_OPERATION_DURATION = Histogram(
-    "graphql_operation_duration_seconds",
-    "GraphQL operation execution time",
-    ["operation_name"],
+
+GRAPHQL_ROOT_FIELD_REQUESTS = Counter(
+    "graphql_root_field_requests_total",
+    "Total number of GraphQL requests by root field",
+    ["root_field", "status"],
+)
+GRAPHQL_ROOT_FIELD_DURATION = Histogram(
+    "graphql_root_field_duration_seconds",
+    "GraphQL operation execution time by root field",
+    ["root_field"],
+    buckets=LATENCY_BUCKETS,
 )
 
 if DEBUG_MODE:
@@ -104,6 +123,16 @@ ASYNC_GRPC_MODEL = async_grpc_model.AsyncGrpcModel(
 )
 
 EXECUTABLE_SCHEMA = prepare_executable_schema()
+ROOT_FIELD_NAMES = frozenset(
+    field_name
+    for root_type in (
+        EXECUTABLE_SCHEMA.query_type,
+        EXECUTABLE_SCHEMA.mutation_type,
+        EXECUTABLE_SCHEMA.subscription_type,
+    )
+    if root_type
+    for field_name in root_type.fields
+)
 
 RESOLVER = crossrefs.XrefResolver(internal_mapping_file="docs/xref_LOD_mapping.json")
 
@@ -228,11 +257,36 @@ class PrometheusGraphQLHTTPHandler(GraphQLHTTPHandler):
         query_document=None,
     ):
         """Execute an operation and record its count, status, and duration."""
-        operation_name = data.get("operationName") if isinstance(data, dict) else None
-        if not isinstance(operation_name, str) or not operation_name:
-            operation_name = "anonymous"
-
         start_time = time.perf_counter()
+        root_fields = ("unknown",)
+
+        if isinstance(data, dict):
+            operation_name = data.get("operationName")
+            if query_document is None and isinstance(data.get("query"), str):
+                try:
+                    query_document = parse(data["query"])
+                except GraphQLError:
+                    pass
+
+            if query_document is not None:
+                operation = get_operation_ast(query_document, operation_name)
+                if operation:
+                    selections = operation.selection_set.selections
+                    fields = {
+                        selection.name.value
+                        for selection in selections
+                        if isinstance(selection, FieldNode)
+                        and selection.name.value in ROOT_FIELD_NAMES
+                    }
+                    if fields:
+                        root_fields = tuple(sorted(fields))
+                    elif any(
+                        isinstance(selection, FieldNode)
+                        and selection.name.value.startswith("__")
+                        for selection in selections
+                    ):
+                        root_fields = ("introspection",)
+
         status = "error"
         try:
             success, result = await super().execute_graphql_query(
@@ -241,13 +295,16 @@ class PrometheusGraphQLHTTPHandler(GraphQLHTTPHandler):
                 context_value=context_value,
                 query_document=query_document,
             )
-            status = "success" if success else "error"
+            if not success or result.get("errors"):
+                status = "error"
+            else:
+                status = "success"
             return success, result
         finally:
-            GRAPHQL_OPERATIONS.labels(operation_name, status).inc()
-            GRAPHQL_OPERATION_DURATION.labels(operation_name).observe(
-                time.perf_counter() - start_time
-            )
+            duration = time.perf_counter() - start_time
+            for root_field in root_fields:
+                GRAPHQL_ROOT_FIELD_REQUESTS.labels(root_field, status).inc()
+                GRAPHQL_ROOT_FIELD_DURATION.labels(root_field).observe(duration)
 
 
 # https://starlette.dev/lifespan/
@@ -269,23 +326,7 @@ APP = applications.Starlette(
 
 Instrumentator(excluded_handlers=["/metrics"]).instrument(
     APP,
-    latency_lowr_buckets=(
-        0.01,
-        0.025,
-        0.05,
-        0.1,
-        0.25,
-        0.5,
-        1,
-        1.25,
-        1.5,
-        1.75,
-        2,
-        2.5,
-        5,
-        10,
-        30,
-    ),
+    latency_lowr_buckets=LATENCY_BUCKETS,
 ).expose(APP, endpoint="/metrics")
 
 # Serve GraphiQL frontend assets (JS/CSS/examples) from this package's `static` dir.

--- a/k8s/web-prod/base/service.yaml
+++ b/k8s/web-prod/base/service.yaml
@@ -9,6 +9,7 @@ spec:
     app: graphql-core
   type: ClusterIP
   ports:
-    - port: 8000
+    - name: graphql-core
+      port: 8000
       protocol: TCP
       targetPort: 8000

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ httpx==0.28.1
 mongomock==4.3.0
 pymongo==4.16.0
 mongomock-motor==0.0.36
+prometheus-fastapi-instrumentator==7.1.0
 python-dotenv==1.0.1
 redis==5.2.0
 requests==2.32.0


### PR DESCRIPTION
## Description

- Exposes metrics at /metrics
- Track request count and duration by query field name [custom-extension-example](https://ariadnegraphql.org/server/Extensions/extensions#custom-extension-example)
- Support multiple Uvicorn workers